### PR TITLE
Fix typos in UML tags

### DIFF
--- a/geoapi-pending/src/main/java/org/opengis/geometry/coordinate/GeometryFactory.java
+++ b/geoapi-pending/src/main/java/org/opengis/geometry/coordinate/GeometryFactory.java
@@ -410,7 +410,7 @@ public interface GeometryFactory {
      * @throws MismatchedDimensionException if geometric objects given in argument don't have
      *         the expected dimension.
      */
-    @UML(identifier="GM_PolyhedralSurace(GM_Polygon)", obligation=MANDATORY, specification=ISO_19107)
+    @UML(identifier="GM_PolyhedralSurface(GM_Polygon)", obligation=MANDATORY, specification=ISO_19107)
     PolyhedralSurface createPolyhedralSurface(List<Polygon> tiles)
             throws MismatchedReferenceSystemException, MismatchedDimensionException;
 

--- a/geoapi-pending/src/main/java/org/opengis/observation/sampling/SamplingCurve.java
+++ b/geoapi-pending/src/main/java/org/opengis/observation/sampling/SamplingCurve.java
@@ -54,7 +54,7 @@ public interface SamplingCurve extends SpatiallyExtensiveSamplingFeature {
     /**
      * Lenght of the curve.
      */
-    @UML(identifier="lenght", obligation=OPTIONAL, specification=OGC_07022)
+    @UML(identifier="length", obligation=OPTIONAL, specification=OGC_07022)
     Measure getLength();
 
     /**

--- a/geoapi-pending/src/main/java/org/opengis/style/portrayal/AttributeValue.java
+++ b/geoapi-pending/src/main/java/org/opengis/style/portrayal/AttributeValue.java
@@ -58,6 +58,6 @@ public interface AttributeValue {
     /**
      * Gets the associated AttributeDefinition.
      */
-    @UML(identifier="attributType", obligation=MANDATORY, specification=ISO_19117)
+    @UML(identifier="attributeType", obligation=MANDATORY, specification=ISO_19117)
     AttributeDefinition getDefinition();
 }

--- a/geoapi/src/main/java/org/opengis/metadata/acquisition/Objective.java
+++ b/geoapi/src/main/java/org/opengis/metadata/acquisition/Objective.java
@@ -98,7 +98,7 @@ public interface Objective {
      *
      * @return events associated with objective completion.
      */
-    @UML(identifier="objectiveOccurence", obligation=MANDATORY, specification=ISO_19115_2)
+    @UML(identifier="objectiveOccurrence", obligation=MANDATORY, specification=ISO_19115_2)
     Collection<? extends Event> getObjectiveOccurences();
 
     /**


### PR DESCRIPTION
I believe any typo in a method name must be ignored for backward compatibility. What about the contents of the `@UML` tags? If they can be updated, this pull request address a few that I found with my IDE.

Thanks
Bruno