### PR TITLE
Fix typo in CylindricalCS class name

### DIFF
--- a/geoapi/src/main/python/opengis/referencing/cs.py
+++ b/geoapi/src/main/python/opengis/referencing/cs.py
@@ -177,7 +177,7 @@ class CartesianCS(CoordinateSystem):
     """
 
 
-class CylindralCS(CoordinateSystem):
+class CylindricalCS(CoordinateSystem):
     """
     A 3-dimensional coordinate system consisting of a PolarCS extended by a straight axis perpendicular to the plane
     spanned by the polar CS.


### PR DESCRIPTION
Just a quick fix. The CylindricalCS class was misspelled as CylindralCS. The "ic" was missing.