### PR TITLE
ISO 19115-1:2014 and ISO 19115-2:2018 Python updates

### DIFF
--- a/geoapi-java-python/src/main/python/opengis/bridge/java/metadata.py
+++ b/geoapi-java-python/src/main/python/opengis/bridge/java/metadata.py
@@ -23,6 +23,7 @@ class MetadataScope(opengis.metadata.base.MetadataScope):
         self._proxy = proxy
 
     @property
+    @abstractmethod
     def resource_scope(self):
         return self._proxy.getResourceScope()
 
@@ -33,6 +34,7 @@ class Citation(opengis.metadata.citation.Citation):
         self._proxy = proxy
 
     @property
+    @abstractmethod
     def title(self):
         return self._proxy.getTitle()
 
@@ -46,18 +48,22 @@ class Identifier(opengis.metadata.citation.Identifier):
         self._proxy = proxy
 
     @property
+    @abstractmethod
     def code(self):
         return self._proxy.getCode()
 
     @property
+    @abstractmethod
     def code_space(self):
         return self._proxy.getCodeSpace()
 
     @property
+    @abstractmethod
     def version(self):
         return self._proxy.getVersion()
 
     @property
+    @abstractmethod
     def description(self):
         return self._proxy.getDescription()
 
@@ -71,14 +77,15 @@ class Identification(opengis.metadata.identification.Identification):
         self._proxy = proxy
 
     @property
+    @abstractmethod
     def citation(self):
         value = self._proxy.getCitation()
         if value:
             return Citation(value)
         else:
-            return None
-
+    
     @property
+    @abstractmethod
     def abstract(self):
         return self._proxy.getAbstract()
 
@@ -92,10 +99,12 @@ class Dimension(opengis.metadata.representation.Dimension):
         self._proxy = proxy
 
     @property
+    @abstractmethod
     def dimension_name(self):
         return self._proxy.getDimensionName()
 
     @property
+    @abstractmethod
     def dimension_size(self) -> int:
         return self._proxy.getDimensionSize()
 
@@ -106,10 +115,12 @@ class GridSpatialRepresentation(opengis.metadata.representation.SpatialRepresent
         self._proxy = proxy
 
     @property
+    @abstractmethod
     def number_of_dimensions(self):
         return self._proxy.getNumberOfDimensions()
 
     @property
+    @abstractmethod
     def axis_dimension_properties(self):
         value = self._proxy.getAxisDimensionProperties()
         if value:
@@ -122,10 +133,12 @@ class GridSpatialRepresentation(opengis.metadata.representation.SpatialRepresent
             return []
 
     @property
+    @abstractmethod
     def cell_geometry(self):
         return self._proxy.getCellGeometry()
 
     @property
+    @abstractmethod
     def transformation_parameter_availability(self):
         return self._proxy.getTransformationParameterAvailability()
 
@@ -136,6 +149,7 @@ class Metadata(opengis.metadata.base.Metadata):
         self._proxy = proxy
 
     @property
+    @abstractmethod
     def metadata_scope(self):
         value = self._proxy.getMetadataScopes()
         if value:
@@ -148,14 +162,15 @@ class Metadata(opengis.metadata.base.Metadata):
             return []
 
     @property
+    @abstractmethod
     def contact(self):
-        return None
 
     @property
+    @abstractmethod
     def date_info(self):
-        return None
 
     @property
+    @abstractmethod
     def identification_info(self):
         value = self._proxy.getIdentificationInfo()
         if value:
@@ -168,6 +183,7 @@ class Metadata(opengis.metadata.base.Metadata):
             return []
 
     @property
+    @abstractmethod
     def spatial_representation_info(self):
         value = self._proxy.getSpatialRepresentationInfo()
         if value:

--- a/geoapi-java-python/src/main/python/opengis/bridge/java/referencing.py
+++ b/geoapi-java-python/src/main/python/opengis/bridge/java/referencing.py
@@ -25,6 +25,7 @@ class IdentifiedObject(opengis.referencing.datum.IdentifiedObject):
         self._proxy = proxy
 
     @property
+    @abstractmethod
     def name(self):
         return Identifier(self._proxy.getName())
 
@@ -41,12 +42,12 @@ class GeodeticDatum(IdentifiedObject, opengis.referencing.datum.GeodeticDatum):
         super().__init__(proxy)
 
     @property
+    @abstractmethod
     def ellipsoid(self):
-        return None
 
     @property
+    @abstractmethod
     def prime_meridian(self):
-        return None
 
 
 
@@ -55,16 +56,17 @@ class CoordinateSystemAxis(IdentifiedObject, opengis.referencing.datum.Identifie
         super().__init__(proxy)
 
     @property
+    @abstractmethod
     def abbreviation(self):
         return self._proxy.getAbbreviation()
 
     @property
+    @abstractmethod
     def direction(self):
-        return None
 
     @property
+    @abstractmethod
     def unit(self):
-        return None
 
 
 
@@ -97,6 +99,7 @@ class CoordinateReferenceSystem(IdentifiedObject, opengis.referencing.crs.Refere
         super().__init__(proxy)
 
     @property
+    @abstractmethod
     def coordinate_system(self):
         return self._proxy.getCoordinateSystem()
 
@@ -116,5 +119,6 @@ class ProjectedCRS(IdentifiedObject, opengis.referencing.crs.DerivedCRS):
         super().__init__(proxy)
 
     @property
+    @abstractmethod
     def base_crs(self):
         return self._proxy.getBaseCRS()

--- a/geoapi/src/main/python/opengis/__init__.py
+++ b/geoapi/src/main/python/opengis/__init__.py
@@ -1,3 +1,29 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the opengis (opengis) package.
+
+This package implements the Open Geospatial Consortium, Inc.'s GeoAPI (geoapi)
+specification in Python and contains geographic structures derived from various
+OGC/ISO international standards.
 """
-Geographic structures derived from OGC/ISO international standard.
-"""
+
+__package_name__ = "opengis"
+__version__ = 4.0
+__author__ = "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
+__license_type__ = "© 2013-2024 Open Geospatial Consortium, Inc.\
+Licensed under the Apache License, Version 2.0."

--- a/geoapi/src/main/python/opengis/geometry/__init__.py
+++ b/geoapi/src/main/python/opengis/geometry/__init__.py
@@ -1,3 +1,25 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the geometry subpackage.
+
+This subpackage contains geometry data structures derived from the
+ISO 19107 international standard.
 """
-Geographic metadata structures derived from the ISO 19107 international standard.
-"""
+
+__author__ = "OGC Topic 1 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"

--- a/geoapi/src/main/python/opengis/geometry/primitive.py
+++ b/geoapi/src/main/python/opengis/geometry/primitive.py
@@ -1,25 +1,525 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2019-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the primitive module.
+
+This module contains primitive geometry data structures derived from
+the ISO 19107 international standard.
+"""
+
+__author__ = "OGC Topic 1 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from enum import Enum
+from typing import Optional
 
 from opengis.referencing.crs import CoordinateReferenceSystem
+from opengis.referencing.cs import CoordinateSystem
+from opengis.util.measure import Angle, Length
 
 
 class DirectPosition(ABC):
-    """Holds the coordinates for a position within some coordinate reference system."""
+    """
+    Holds the coordinates for a position within some coordinate
+    reference system.
+    """
+
+    @property
+    @abstractmethod
+    def coordinate(self) -> Sequence[int | float]:
+        """
+        A sequence of real numbers that hold the coordinate values for this
+        position in the specified reference system.
+        """
 
     @property
     @abstractmethod
     def coordinate_reference_system(self) -> CoordinateReferenceSystem:
-        """The coordinate reference system in which the coordinate tuple is given."""
-        pass
+        """
+        The coordinate reference system in which the coordinate tuple is given.
+        """
 
     @property
     @abstractmethod
     def dimension(self) -> int:
         """The length of coordinate sequence (the number of entries)."""
-        pass
+
+
+class Envelope(ABC):
+    """
+    An `Envelope` is often referred to as a box or rectangle defining a minimum
+    enclosing area. Whatever its size, an `Envelope` can be represented
+    unambiguously as two `DirectPositions` (coordinate points). To code an
+    `Envelope`, you simply need to code these two points. This is consistent
+    with all the coordinate systems in ISO 19107:2019. It should be remembered
+    that, even if the CoordinateSystem is purely spatial without being
+    globally bijective, the coordinate may not be valid in the associated
+    coordinate system.
+    """
+
+    @property
+    @abstractmethod
+    def lower_corner(self) -> DirectPosition:
+        """
+        The “lowerCorner” of an Envelope is a coordinate position consisting
+        of all the minimum coordinates for each dimension, for all points
+        within the Envelope.
+
+        Math: For each coordinate offset, the corresponding lower corner
+        offset is the minimum of that offset in all direct positions of the
+        original geometry, and the corresponding upper corner offset is the
+        maximum of those same direct positions.
+        """
+
+    @property
+    @abstractmethod
+    def upper_corner(self) -> DirectPosition:
+        """
+        The “upperCorner” of an Envelope is a coordinate position consisting
+        of all the maximum coordinates for each dimension, for all points
+        within the Envelope.
+
+        Offset in all direct positions of the original geometry.
+        """
+
+
+class Rotation(Enum):
+    """
+    `Rotation` enumerates the two potential directions of rotation for an
+    angular measurement, clockwise and anti-clockwise. These directions
+    of rotation are considered as seen from above the reference surface.
+    """
+    CLOCKWISE_RIGHT = "clockwise/right"
+    COUNTER_CLOCKWISE_LEFT = "counter-clockwise/left"
+
+
+class ReferenceDirection(ABC):
+    """
+    The ReferenceDirection interface is empty, but must be “implemented” by
+    any data type that can represent a direction (or tangent unit vector) at
+    a point. This leads to a circular, but valid, possibly recursive
+    definition for the Bearing data type.
+    """
+
+
+class CurveRelativeDirection(Enum):
+    """
+    `CurveRelativeDirection` refers to the vectors associated with
+    a curve. Some common vector directions are:
+
+        - tangent, the direction in which the curve points;
+        - the inverse tangent, i.e. the opposite of the tangent;
+        - the binormal, the direction towards the center of curvature, i.e.
+            the inside of the curve;
+        - the inverse binormal (reverseBiNormal), the opposite of the
+            binormal, on the outside of the curve;
+        - leftNormal, to the left of the tangent;
+        - rightNormal, to the right of the tangent;
+        - upNormal, relative to the reference surface;
+        - downNormal, the opposite of upNormal.
+
+    These values can be used to extend or replace the 2D directions
+    of `RelativeDirection`.
+    """
+    TANGENT = "tangent"
+    REVERSE_TANGENT = "reverseTangent"
+    NORMAL = "normal"
+    REVERSE_NORMAL = "reverseNormal"
+    BINORMAL = "biNormal"
+    REVERSE_BINORMAL = "reverseBiNormal"
+    LEFT_NORMAL = "leftNormal"
+    RIGHT_NORMAL = "rightNormal"
+    UP_NORMAL = "upNormal"
+    DOWN_NORMAL = "downNormal"
+
+
+class RelativeDirection(Enum):
+    """
+    `RelativeDirection` enumerates common potential relative reference
+    directions for azimuth, generally used in reference to a moving
+    vehicle. Common values include front, rear, port (90° left) or
+    starboard (90° right).
+    """
+    FORE_FOREWARD = "fore/forward"
+    AFT_BACKWARD = "aft/backward"
+    PORT_LEFT = "port/left"
+    STARBOARD_RIGHT = "starboard/right"
+
+
+class FixedDirection(Enum):
+    """
+    `FixedDirection` enumerates common potential fixed reference directions
+    for azimuth, generally used in reference to the globe, a map,
+    a coordinate system or a grid. Common values include true north or south,
+    magnetic north or south, grid north or south (reference to a grid
+    or projection).
+    """
+    TRUE_NORTH = "trueNorth"
+    MAGNETIC_NORTH = "magneticNorth"
+    GRID_NORTH = "gridNorth"
+    TRUE_SOUTH = "trueSouth"
+    MAGNETIC_SOUTH = "magneticsouth"
+    GRID_SOUTH = "gridsouth"
+
+
+class Bearing(ABC):
+    """
+    The Bearing data type indicates a direction. The azimuth can take one
+    of two forms forms:
+
+    - a set of angles, one of which is a plane azimuth and the second a
+      measure of altitude (positive above the horizontal, negative below
+      the horizon). above the horizontal, negative below the horizon),
+      essentially by creating a spherical spherical coordinate system;
+
+    - a directional vector derived from the coordinate system at the
+      initial point, a unit vector with the direction associated with
+      the set of angles.
+
+    Since the two types of measurement are identical, the azimuth values
+    are the same, but the interpretations will depend on the usage (usually
+    a reference direction, the offset “0”). will depend on usage (usually a
+    reference direction, offset “0”, and a direction of rotation, clockwise).
+
+    The value of the Bearing data type can only be valid at the point from
+    which the measurement is taken. The common “parallel” transformation of
+    vectors from one point to another is only valid if the
+    `GeometricReferenceSurface` used is planar (i.e. Cartesian and, therefore,
+    Euclidean). The fundamental problem is that the sphere has no universally
+    valid 2D world coordinate system for its tangent spaces. Using a fixed
+    direction reference such as “true north” does allow some translation,
+    however, if the reference exists and is unique at a given position.
+    For example, north does not exist at the North Pole and is not unique at
+    the South Pole.
+
+    Azimuths can be measured in both directions, as absolute values (such as
+    true north, see azimuth) or relative (such as “before” or “after”).
+    """
+
+    @abstractmethod
+    def __init__(self,
+                 v: 'Vector',
+                 reference: ReferenceDirection |
+                    CurveRelativeDirection |
+                    RelativeDirection |
+                    FixedDirection,
+                 rotation: Rotation,
+                 ):
+        """
+        The default azimuth constructor considers a non-zero vector at a
+        point and creates an azimuth at that point, with the classic default
+        values for the most common fixed azimuth.
+        """
+
+    @property
+    @abstractmethod
+    def angle(self) -> Sequence[Angle]:
+        """
+        In this variant of Bearing, generally used for 2D coordinate systems,
+        the first angle (azimuth) is measured from a coordinate axis (usually
+        north) in a clockwise direction, parallel to the tangent plane of the
+        reference surface. Given two angles, the second angle (altitude)
+        generally represents the angle above (for positive angles) or below
+        (for negative angles) a local plane parallel to the tangent plane
+        of the reference surface.
+
+        NOTE: 1 or more angles should be returned.
+        """
+
+    @property
+    @abstractmethod
+    def direction(self) -> Optional['Vector']:
+        """
+        In this variant of Bearing, generally used for 3D coordinate systems,
+        the direction is expressed as an arbitrary vector in the
+        coordinate system.
+        """
+
+    @property
+    @abstractmethod
+    def reference(self) -> ReferenceDirection:
+        """
+        The reference attribute is the direction from which the azimuth is
+        measured, i.e. the direction of a positive measurement. Most systems
+        can use a negative number to express a measurement opposite to the
+        default rotation.
+        """
+
+    @property
+    @abstractmethod
+    def rotation(self) -> Rotation:
+        """
+        The rotation attribute specifies the direction from which the azimuth
+        is measured.
+        """
+
+
+class Vector(ABC):
+    """
+    The common “vector” in Euclidean spaces can be translated to any point
+    in space because the flat nature of Euclidean space has a universal
+    coordinate system that works at any “starting” point of a vector.
+
+    The Vector data type in this document must be associated with a point
+    on the GeometricReferenceSurface, which must be well defined.
+    The directional parts of the vector must also specify the
+    “starting position” of the vector. Where the coordinate system performs
+    well, the generating family of vectors in tangent space is represented
+    in 3D geocentric space by the tangents to the coordinate functions.
+    For example, in a latitude-longitude system, the unit vectors tangent
+    to the constant longitude curves, as well as to the latitude curves,
+    represent a local tangent space basis, except for the poles where the
+    longitude function has a zero tangent. longitude function has a zero
+    tangent at the pole. If (lat, long = (dφ, dλ), then the symbols (dφ, dλ)
+    are the differentials of the two-coordinate functions represented by the
+    tangents in the direction of increasing φ, respectively λ, and represent
+    a basis for local tangent spaces.
+    """
+
+    @abstractmethod
+    def __init__(self,
+                 position: DirectPosition,
+                 coordinates: float | None = None,
+                 direction: Bearing | None = None,
+                 length: Length | None = None,
+                 ) -> None:
+        """
+        The constructor vector creates a vector with the given offsets or
+        direction and length at the specified direct position, in the
+        coordinate space of the direct position.
+
+        NOTE: if `coordinates` is not specified then `direction` and `length`
+        must be specified. Likewise if `direction` or `length` is not specified
+        then `coordinates` must be specified.
+        """
+
+    @property
+    @abstractmethod
+    def origin(self) -> DirectPosition:
+        """
+        The origin attribute is the location of the point on the
+        `GeometricReferenceSurface` for which the vector is a tangent.
+        The direct position is associated with the coordinate system.
+        This determines the coordinate system for the vector. The spatial
+        dimension of the direct position determines the dimension of
+        the vector.
+        """
+
+    @property
+    @abstractmethod
+    def offsets(self) -> Sequence[float]:
+        """
+        The offset attribute uses the direct position coordinate system and
+        represents the local tangent vector vector in the local
+        coordinate differentials.
+
+        EXAMPLE: If the Euclidean (E²) plane is used, then the `DirectPosition`
+        is a pair of coordinates (x, y) and the the vector consists of the
+        differentials in both directions. Consequently, the offset is of
+        length 2 and has a coordinate base of (dx, dy).
+        """
+
+    @property
+    @abstractmethod
+    def dimension(self) -> int:
+        """
+        The dimension attribute is the dimension of the origin and,
+        consequently, the dimension of the tangent space of the vector.
+        """
+
+    @property
+    @abstractmethod
+    def coordinate_system(self) -> CoordinateSystem:
+        """
+        The `coordinate_system` attribute is the origin system and, therefore,
+        determines the coordinates of the local tangent space in which the
+        vector exists.
+        """
+
+    @abstractmethod
+    def cross_product(self, v2: 'Vector') -> 'Vector':
+        """
+        The cross product is a third vector perpendicular to the other two.
+        If the vector space is only two-dimensional, the cross product gives
+        an oriented intensity and not a vector.
+        """
+
+    @abstractmethod
+    def dot_product(self, v2: 'Vector') -> float:
+        """
+        The dot product operation yields a real value which is the sum of the
+        products of the corresponding coefficients coefficients of the
+        two vectors.
+        """
+
+
+class TransfiniteSetOfDirectPositions(ABC):
+    """
+    Many geometry operations are based on simple set theory, which does not
+    vary according to the cardinality of the sets concerned. Unfortunately,
+    the term “set” in most programming languages refers to a finite collection
+    of objects or object identities. The abstract class
+    `TransfiniteSetOfDirectPositions` represents set-theoretic operations that
+    cannot always be tested by simple enumeration techniques for sets with a
+    small number of elements.
+
+    A `TransfiniteSetOfDirectPositions` can be very large in terms of its
+    number of elements (limited only to a finite number by the use of
+    finite-precision numerical computation). The collection
+
+    {x ∈ R |0 ≤ x ≤ 1}
+
+    is logically infinite. On a digital computer, it may consist of only
+    2^64 objects. That's a lot, but it's not infinite. The term “transfinite”
+    indicates that nothing on a digital computer is truly infinite, but that
+    doesn't prevent it from being too big to process in a reasonable
+    time interval.
+    """
+
+    @abstractmethod
+    def contains(self, pt: DirectPosition) -> bool:
+        """
+        Determine whether a particular `DirectPosition` is part of the set.
+        Each type of `Geometry` interface will have to implement this with
+        the limitations of a computing platform with limited precision.
+
+        Let À be a transfinite set of direct positions. Then we have:
+            [x ∈ A] ⇒ [A.contains(x) = TRUE]
+        """
+
+
+class Geometry(TransfiniteSetOfDirectPositions):
+    """
+    Geometry is the base class of the geometric object taxonomy, supporting
+    interfaces common to all geographically referenced geometric objects.
+    Instances of `Geometry` are sets of `DirectPosition` attributes in a
+    particular reference coordinate system. `Geometry` can be thought of as an
+    infinite set of points that satisfies the set operation interfaces for a
+    set of direct positions constituting a `TransfiniteSetOfDirectPositions`
+    (essentially a set defined by a `bool` “isIn” operator). As an infinite
+    collection class cannot be implemented directly, a `bool` inclusion test
+    must be provided by the `Geometry` interface. This document focuses on
+    vector geometry classes, but future developments may use `Geometry` as a
+    base class without modification.
+
+    NOTE 1: As a type, `Geometry` has neither a well-defined default state
+    nor a value representation as a data type. As far as these are concerned,
+    instantiated subclasses of `Geometry` do.
+
+    NOTE 2: In its current state this abstract class is a partial
+    implementation of the `Geometry` interface described in ISO 19107:2019.
+    """
+
+    @property
+    @abstractmethod
+    def is_empty(self) -> bool:
+        """
+        The boolean `is_empty` attribute indicates that the geometric object
+        instance is the empty set. Since the empty set is unique, all empty
+        objects are “spatially equivalent” to any other empty object.
+        As soon as an instance is known to be empty (`self.is_empty = True`),
+        the rest of the information in the object becomes redundant until the
+        boolean value `self.is_empty` is reset to `False`.
+
+        If the `is_empty` attribute is set to `True`, the object is locked
+        until the `is_empty` attribute is set to `False`. Essentially, setting
+        the `is_empty` attribute to `True` changes the behavior (as defined by
+        its class) of the object to match the `Empty` class, defined in
+        ISO 19107:2019 section 6.4.10.
+        """
+
+    @property
+    @abstractmethod
+    def coordinate_reference_system(self) -> CoordinateReferenceSystem:
+        """
+        The coordinate reference system in which the coordinate geometry
+        is given.
+        """
+
+
+class Primitive(Geometry):
+    """
+    A geometry primitive is a related geometric object with a uniform
+    dimension at each interior point. Depending on the spatial dimension
+    of the coordinate space, primitives are made up of the subclasses Point,
+    Curve, Surface and Solid.
+    """
+
+    @property
+    @abstractmethod
+    def segment(self) -> Optional[Sequence['Primitive']]:
+        """
+        The `segment` role lists the components (smallest primitives of the
+        same dimension contained) of Primitive, each of which defines aGeometry
+        portion of the Primitive. The order of the segments is the order in
+        which they are used to define the Primitive.
+        """
+
+
+class Point(Primitive):
+    """
+    A Geometry Point instance is a unique location given by a direct position.
+    """
+
+    @property
+    @abstractmethod
+    def position(self) -> DirectPosition:
+        """
+        The `position` attribute gives the location of the `Point` in its
+        reference system. The distinction between `Point` and `DirectPosition`
+        lies in the fact that `Point` as an object instance has an identity
+        provided by the system, whereas a `DirectPosition` instance is a data
+        type whose only identity is its own value.
+        """
+
+    @property
+    @abstractmethod
+    def boundary(self) -> Geometry:
+        """
+        The “boundary” attribute gives the Point's boundary in the form of a
+        `Geometry` reference system. Since a point's boundary is always empty,
+        the boundary object will always have the value is_empty = TRUE.
+        """
+
+    @abstractmethod
+    def bearing(self, to_point: DirectPosition) -> Bearing:
+        """
+        The `bearing` operation is similar to `vector_to_point` without the
+        distance information in the vector. It is essentially a constructor
+        for `Bearing` based on this point and a target point.
+        """
+
+    @abstractmethod
+    def point_at_distance(self, bearing: Vector) -> DirectPosition:
+        """
+        The `point_at_distance` operation will return a `DirectPosition`
+        attribute given a vector in space tangent to the point whose direction
+        determines a geodesic curve that intersects this `DirectPosition` at
+        a distance equal to the length of the vector. This operation solves
+        the first geodesic problem.
+        """
+
+    @abstractmethod
+    def vector_to_point(self, to_point: DirectPosition) -> Vector:
+        """
+        The `vector_to_point` operation will return a vector in space tangent
+        to the point whose direction determines a geodesic curve that
+        intersects `to_point` at a distance equal to the length of the vector.
+        This operation solves the second geodesic problem.
+        """

--- a/geoapi/src/main/python/opengis/metadata/__init__.py
+++ b/geoapi/src/main/python/opengis/metadata/__init__.py
@@ -1,3 +1,26 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the metadata subpackage.
+
+This subpackage contains geographic metadata structures derived from the
+ISO 19115-1:2014, including addendums A1(2018) and A2(2020),
+and ISO 19115-2:2019, including addendum A1(2022) international standards.
 """
-Geographic metadata structures derived from the ISO 19115-1:2014 international standard.
-"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"

--- a/geoapi/src/main/python/opengis/metadata/acquisition.py
+++ b/geoapi/src/main/python/opengis/metadata/acquisition.py
@@ -1,326 +1,623 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the acquisition module.
+
+This subpackage contains geographic metadata structures regarding data
+acquisition that are derived from the ISO 19115-2:2019 international
+standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
+
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import datetime, date
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import Citation, Identifier, Responsibility
+from opengis.metadata.constraints import Constraints
+from opengis.metadata.extent import Extent
+from opengis.metadata.identification import ProgressCode
+from opengis.metadata.naming import Record, RecordType
+from opengis.metadata.maintenance import Scope
 
 
 class ContextCode(Enum):
-    ACQUISITION = "acquisition"
-    PASS = "pass"
-    WAY_POINT = "wayPoint"
+    """
+    Designation of criterion for defining the context of the scanning
+    process event.
+    """
 
+    ACQUISITION = "acquisition"
+    """Event related to a specific collection."""
+
+    PASS = "pass"
+    """Event related to a sequence of collections."""
+
+    WAY_POINT = "wayPoint"
+    """Event related to a navigational manoeuvre."""
+
+
+class EventTypeCode(Enum):
+    """Type of event related to a platform, instrument, or sensor."""
+
+    ANNOUNCEMENT = "announcement"
+    """
+    Announcementannouncement about future events relevant to the
+    platform/instrument/sensor.
+    """
+
+    CALIBRATION = "calibration"
+    """Calibration event for the platform/instrument/sensor."""
+
+    CALIBRATION_COEFFICIENT_UPDATE = "calibrationCoefficientUpdate"
+    """Update of calibration information for the platform/instrument/sensor."""
+
+    DATA_LOSS = "dataLoss"
+    """Event related to data loss."""
+
+    FATAL = "fatal"
+    """Event that renders the platform/instrument/sensor unusable."""
+
+    MANOEUVRE = "manoeuvre"
+    """Event related to a manoeuvre of the platform/instrument/sensor."""
+
+    MISSING_DATA = "missingData"
+    """Event related to missing data from the platform/instrument/sensor."""
+
+    NOTICE = "notice"
+    """Notice about events related to the platform/instrument/sensor."""
+
+    PRELAUNCH = "prelaunch"
+    """Event related to prelaunch period for the platform/instrument/sensor."""
+
+    SEVERE = "severe"
+    """
+    Event with significant impact on the performance of the platform/
+    instrument/sensor.
+    """
+
+    SWITCH_OFF = "switchOff"
+    """Event related to switching off platform/instrument/sensor."""
+
+    SWITCH_ON = "switchOn"
+    """Event related to switching on platform/instrument/sensor."""
+
+    CLEAN = "clean"
+    """Event related to cleaning the platform/instrument/sensor."""
 
 
 class GeometryTypeCode(Enum):
-    POINT = "point"
-    LINEAR = "linear"
-    AREAL = "areal"
-    STRIP = "strip"
+    """Geometric description of the collection."""
 
+    POINT = "point"
+    """Single geographic point of interest."""
+
+    LINEAR = "linear"
+    """Extended collection in a single vector."""
+
+    AREAL = "areal"
+    """Collection of a geographic area defined by a polygon (coverage)."""
+
+    STRIP = "strip"
+    """Series of linear collections grouped by way points."""
 
 
 class ObjectiveTypeCode(Enum):
-    INSTANTANEOUS_COLLECTION = "instantaneousCollection"
-    PERSISTENT_VIEW = "persistentView"
-    SURVEY = "survey"
+    """Temporal persistence of collection objective."""
 
+    INSTANTANEOUS_COLLECTION = "instantaneousCollection"
+    """Single instance of collection."""
+
+    PERSISTENT_VIEW = "persistentView"
+    """Multiple instances of collection."""
+
+    SURVEY = "survey"
+    """Collection over specified domain."""
 
 
 class OperationTypeCode(Enum):
-    REAL = "real"
-    SIMULATED = "simulated"
-    SYNTHESIZED = "synthesized"
+    """
+    Code indicating whether the data contained in this packet is real
+    (originates from live-fly or other non-simulated operational sources),
+    simulated (originates from target simulator sources), or synthesized
+    (a mix of real and simulated data).
+    """
 
+    REAL = "real"
+    """Originates from live-fly or other non-simulated operational source."""
+
+    SIMULATED = "simulated"
+    """Originates from target simulator sources."""
+
+    SYNTHESIZED = "synthesized"
+    """Mix of real and simulated data."""
 
 
 class PriorityCode(Enum):
-    CRITICAL = "critical"
-    HIGH_IMPORTANCE = "highImportance"
-    MEDIUM_IMPORTANCE = "mediumImportance"
-    LOW_IMPORTANCE = "lowImportance"
+    """Ordered list of priorities."""
 
+    CRITICAL = "critical"
+    """Of decisive importance."""
+
+    HIGH_IMPORTANCE = "highImportance"
+    """Requires resources to be made available."""
+
+    MEDIUM_IMPORTANCE = "mediumImportance"
+    """Normal operation priority."""
+
+    LOW_IMPORTANCE = "lowImportance"
+    """To be completed when resources are available."""
 
 
 class SequenceCode(Enum):
-    START = "start"
-    END = "end"
-    INSTANTANEOUS = "instantaneous"
+    """Temporal relation of activation."""
 
+    START = "start"
+    """Beginning of collection."""
+
+    END = "end"
+    """End of collection."""
+
+    INSTANTANEOUS = "instantaneous"
+    """Collection without a significant duration."""
 
 
 class TriggerCode(Enum):
+    """Mechanism of activation."""
+
     AUTOMATIC = "automatic"
+    """Event due to external stimuli."""
+
     MANUAL = "manual"
+    """Event manually instigated."""
+
     PRE_PROGRAMMED = "preProgrammed"
+    """Event instaigated by planned internal stimuli."""
 
 
+class Revision(ABC):
+    """History of the revision of an event"""
 
-from opengis.metadata.citation import Citation, Identifier, Responsibility
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Description of the revision."""
+
+    @property
+    @abstractmethod
+    def responsible_party(self) -> Sequence[Responsibility]:
+        """Individual or organisation responsible for the revision."""
+
+    @property
+    @abstractmethod
+    def date_info(self) -> Sequence[date]:
+        """Information about dates related to the revision."""
+
+
+class InstrumentEvent(ABC):
+    """An event related to a platform, instrument, or sensor."""
+
+    @property
+    @abstractmethod
+    def citation(self) -> Optional[Sequence[Citation]]:
+        """Citation to the `InstrumentEvent`."""
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Description of the `InstumentEvent`."""
+
+    @property
+    @abstractmethod
+    def extent(self) -> Optional[Sequence[Extent]]:
+        """Extent of the `InstrumentEvent`."""
+
+    @property
+    @abstractmethod
+    def type(self) -> EventTypeCode:
+        """Type of the `InstrumentEvent`."""
+
+    @property
+    @abstractmethod
+    def revision_history(self) -> Optional[Sequence[Revision]]:
+        """History of the revisions of the `InstrumentEvent`."""
+
+
+class InstrumentEventList(ABC):
+    """List of events relaed to platform, instrument, or sensor."""
+
+    @property
+    @abstractmethod
+    def citation(self) -> Optional[Sequence[Citation]]:
+        """Citation to the `InstrumentEventList`."""
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """
+        Description of the language and character set used for the
+        `InstrumentationEventList`.
+        """
+
+    @property
+    @abstractmethod
+    def locale(self) -> Optional[str]:
+        """
+        Description of the language and character set used for the
+        `InstrumentationEventList`. A string conforming to IETF BCP 47.
+        """
+
+    @property
+    @abstractmethod
+    def constraints(self) -> Optional[Sequence[Constraints]]:
+        """Use and access constraints."""
+
+    @property
+    @abstractmethod
+    def instrumentation_event(self) -> Optional[Sequence[InstrumentEvent]]:
+        """Events(s) in the list of events."""
+
 
 class Instrument(ABC):
     """Designations for the measuring instruments."""
 
     @property
-    def citation(self) -> Sequence[Citation]:
+    @abstractmethod
+    def citation(self) -> Optional[Sequence[Citation]]:
         """Complete citation of the instrument."""
-        return None
 
     @property
     @abstractmethod
     def identifier(self) -> Identifier:
-        """Complete citation of the instrument."""
-        pass
+        """Unique identification of the instrument."""
 
     @property
     @abstractmethod
     def type(self) -> str:
-        """Code describing the type of instrument."""
-        pass
+        """
+        Name of the type of instrument. Examples: framing, line-scan,
+        push-broom, pan-frame.
+        """
 
     @property
-    def description(self) -> str:
+    @abstractmethod
+    def description(self) -> Optional[str]:
         """Textual description of the instrument."""
-        return None
 
     @property
-    def mounted_on(self) -> 'Platform':
-        return None
+    @abstractmethod
+    def mounted_on(self) -> Optional['Platform']:
+        """Platform on which the instrument is mounted"""
 
+    @property
+    @abstractmethod
+    def sensor(self) -> Optional[Sequence['Sensor']]:
+        """Instrument has a sensor."""
+
+    @property
+    @abstractmethod
+    def history(self) -> Optional['InstrumentEventList']:
+        """List of events associated with the instrument."""
+
+
+class Sensor(Instrument):
+    """Specific type of instrument"""
+
+    @property
+    @abstractmethod
+    def hosted(self) -> Optional[Instrument]:
+        """Instrument on which the sensor is hosted"""
 
 
 class Platform(ABC):
     """Designations for the platform used to acquire the dataset."""
 
     @property
-    def citation(self) -> Citation:
+    @abstractmethod
+    def citation(self) -> Optional[Citation]:
         """Complete citation of the platform."""
-        return None
 
     @property
     @abstractmethod
     def identifier(self) -> Identifier:
         """Unique identification of the platform."""
-        pass
 
     @property
     @abstractmethod
     def description(self) -> str:
         """Narrative description of the platform supporting the instrument."""
-        pass
 
     @property
-    def sponsor(self) -> Sequence[Responsibility]:
-        """Organization responsible for building, launch, or operation of the platform."""
-        return None
+    @abstractmethod
+    def sponsor(self) -> Optional[Sequence[Responsibility]]:
+        """
+        Organisation responsible for building, launch, or operation of the
+        platform.
+        """
+
+    @property
+    @abstractmethod
+    def other_property(self) -> Optional[Record]:
+        """Instance of other property type not included in `Sensor`."""
+
+    @property
+    @abstractmethod
+    def other_property_type(self) -> Optional[RecordType]:
+        """Type of other property description."""
 
     @property
     @abstractmethod
     def instrument(self) -> Sequence[Instrument]:
-        pass
+        """Instrument(s) mounted on a platform"""
 
+    @property
+    @abstractmethod
+    def history(self) -> Optional[Sequence[InstrumentEventList]]:
+        """List of events affecting a platform."""
 
 
 class PlatformPass(ABC):
-    """Identification of collection coverage."""
+    """Identification of collection coverage. Identifies a particular pass
+    made by the platform during data acquisition. A platform pass is used to
+    provide supporting identifying information for an event and for data
+    acquisition of a particular objective."""
 
     @property
     @abstractmethod
     def identifier(self) -> Identifier:
         """Unique name of the pass."""
-        pass
 
     @property
-    def extent(self):
-        """Area covered by the pass."""
-        return None
+    @abstractmethod
+    def extent(self) -> Optional[Extent]:
+        """Temporal and spatial extent of the pass."""
 
     @property
-    def related_event(self) -> Sequence['Event']:
-        return None
+    @abstractmethod
+    def related_event(self) -> Optional[Sequence['Event']]:
+        """Occurrence of one or more events for a pass."""
 
-
-
-from datetime import datetime
 
 class Event(ABC):
-    """Identification of a significant collection point within an operation."""
+    """
+    Identification of a significant collection point within an
+    operation.
+    """
 
     @property
     @abstractmethod
     def identifier(self) -> Identifier:
         """Event name or number."""
-        pass
 
     @property
     @abstractmethod
     def trigger(self) -> TriggerCode:
         """Initiator of the event."""
-        pass
 
     @property
     @abstractmethod
     def context(self) -> ContextCode:
         """Meaning of the event."""
-        pass
 
     @property
     @abstractmethod
     def sequence(self) -> SequenceCode:
         """Relative time ordering of the event."""
-        pass
 
     @property
     @abstractmethod
     def time(self) -> datetime:
         """Time the event occurred."""
-        pass
 
     @property
+    @abstractmethod
+    def expected_objective(self) -> Optional[Sequence['Objective']]:
+        """An objective expected to be completed by the event."""
+
+    @property
+    @abstractmethod
     def related_pass(self) -> PlatformPass:
-        return None
+        """A `PlatformPass` related to the `Event`."""
 
     @property
+    @abstractmethod
     def related_sensor(self) -> Sequence[Instrument]:
-        return None
-
-    @property
-    def expected_objective(self) -> Sequence['Objective']:
-        return None
-
+        """An `Instrument` related to
+            the event."""
 
 
 class EnvironmentalRecord(ABC):
+    """
+    Information about the environmental conditions during the acquisition.
+    """
 
     @property
     @abstractmethod
-    def average_air_temperature(self) -> float:
-        pass
+    def average_air_temperature(self) -> Optional[float]:
+        """
+        Average air temperature along the flight pass during the photo flight.
+        """
 
     @property
     @abstractmethod
-    def max_relative_humidity(self) -> float:
-        pass
+    def max_relative_humidity(self) -> Optional[float]:
+        """
+        Maximum realative humitiy along the flight pass during the photo
+        flight.
+        """
 
     @property
     @abstractmethod
-    def max_altitude(self) -> float:
-        pass
+    def max_altitude(self) -> Optional[float]:
+        """
+        Maximum altitude during the photo flight.
+        """
 
     @property
     @abstractmethod
-    def meteorological_conditions(self) -> str:
-        pass
+    def meteorological_conditions(self) -> Optional[str]:
+        """
+        Meteorological conditions in the photo flight area, in particular
+        clouds, snow, and wind.
+        """
 
+    @property
+    @abstractmethod
+    def solar_azimuth(self) -> Optional[float]:
+        """
+        Clockwise angle in degrees from north to the centre of the sun's disc.
 
+        NOTE: This Angle is calculated from the nadir point of the sensor, not
+        the centre point of the image.
+        """
 
-from opengis.metadata.extent import Extent
+    @property
+    @abstractmethod
+    def solar_elevation(self) -> Optional[float]:
+        """
+        Angle between the horizonand the centre of the sun's disk.
+        """
+
 
 class Objective(ABC):
-    """Describes the characteristics, spatial and temporal extent of the intended object to be observed."""
+    """
+    Describes the characteristics, spatial and temporal extent of the intended
+    object to be observed.
+    """
 
     @property
     @abstractmethod
     def identifier(self) -> Sequence[Identifier]:
         """Registered code used to identify the objective."""
-        pass
-
-    @property
-    def priority(self) -> str:
-        """Priority applied to the target."""
-        return None
-
-    @property
-    def type(self) -> Sequence[ObjectiveTypeCode]:
-        """Collection technique for the objective."""
-        return None
-
-    @property
-    def function(self) -> Sequence[str]:
-        """Function performed by or at the objective."""
-        return None
-
-    @property
-    def extent(self) -> Sequence[Extent]:
-        """Extent information including the bounding box, bounding polygon, vertical and temporal extent of the objective."""
-        return None
-
-    @property
-    def sensing_instrument(self) -> Sequence[Instrument]:
-        return None
-
-    @property
-    def platformPass(self) -> Sequence[PlatformPass]:
-        return None
 
     @property
     @abstractmethod
-    def objective_occurence(self) -> Sequence[Event]:
-        pass
+    def priority(self) -> Optional[str]:
+        """Priority applied to the target."""
 
+    @property
+    @abstractmethod
+    def type(self) -> Optional[Sequence[ObjectiveTypeCode]]:
+        """Collection technique for the objective."""
 
+    @property
+    @abstractmethod
+    def function(self) -> Optional[Sequence[str]]:
+        """Function performed by or at the objective."""
 
-from opengis.metadata.identification import ProgressCode
+    @property
+    @abstractmethod
+    def extent(self) -> Optional[Sequence[Extent]]:
+        """
+        Extent information including the bounding box, bounding polygon,
+        vertical and temporal extent of the objective.
+        """
+
+    @property
+    @abstractmethod
+    def objective_occurence(self) -> Optional[Sequence[Event]]:
+        """Event or events associated with objective completion."""
+
+    @property
+    @abstractmethod
+    def platform_pass(self) -> Optional[Sequence[PlatformPass]]:
+        """Pass of the platform over the objective."""
+
+    @property
+    @abstractmethod
+    def sensing_instrument(self) -> Optional[Sequence[Instrument]]:
+        """Instrument which senses the objective data."""
+
 
 class Operation(ABC):
     """Designations for the operation used to acquire the dataset."""
 
     @property
-    def description(self) -> str:
-        """Description of the mission on which the platform observations are part and the objectives of that mission."""
-        return None
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """
+        Description of the mission on which the platform observations are part
+        and the objectives of that mission.
+        """
 
     @property
-    def citation(self) -> Citation:
-        """Character string by which the mission is known."""
-        return None
+    @abstractmethod
+    def citation(self) -> Optional[Citation]:
+        """Identification of the mission."""
 
     @property
-    def identifier(self) -> Identifier:
-        """Character string by which the mission is known."""
-        return None
+    @abstractmethod
+    def identifier(self) -> Optional[Identifier]:
+        """Unique identification of the operation."""
 
     @property
     @abstractmethod
     def status(self) -> ProgressCode:
         """Status of the data acquisition."""
-        pass
 
     @property
-    def type(self) -> OperationTypeCode:
-        """Status of the data acquisition."""
-        return None
+    @abstractmethod
+    def type(self) -> Optional[OperationTypeCode]:
+        """Collection technique for the operation."""
 
     @property
+    @abstractmethod
+    def other_property(self) -> Optional[Record]:
+        """Instance of other property type not included in `Sensor`."""
+
+    @property
+    @abstractmethod
+    def other_property_type(self) -> Optional[RecordType]:
+        """Type of other property description."""
+
+    @property
+    @abstractmethod
+    def child_operation(self) -> Optional[Sequence['Operation']]:
+        """Sub-missions that make up part of a larger mission."""
+
+    @property
+    @abstractmethod
+    def objective(self) -> Optional[Sequence[Objective]]:
+        """Object(s) or area(s) of interest to be sensed."""
+
+    @property
+    @abstractmethod
     def parent_operation(self) -> 'Operation':
-        return None
+        """Heritage of the operation."""
 
     @property
-    def child_operation(self) -> Sequence['Operation']:
-        return None
+    @abstractmethod
+    def plan(self) -> Optional['Plan']:
+        """Plan satisfied by th operation."""
 
     @property
-    def platform(self) -> Sequence[Platform]:
+    @abstractmethod
+    def platform(self) -> Optional[Sequence[Platform]]:
         """Platform (or platforms) used in the operation."""
-        return None
 
     @property
-    def objective(self) -> Sequence[Objective]:
-        return None
-
-    @property
-    def plan(self) -> 'Plan':
-        return None
-
-    @property
-    def significant_event(self) -> Sequence[Event]:
-        return None
-
+    @abstractmethod
+    def significant_event(self) -> Optional[Sequence[Event]]:
+        """Record of an event occuring during an operation."""
 
 
 class RequestedDate(ABC):
@@ -330,123 +627,147 @@ class RequestedDate(ABC):
     @abstractmethod
     def requested_date_of_collection(self) -> datetime:
         """Preferred date and time of collection."""
-        pass
 
     @property
     @abstractmethod
     def latest_acceptable_date(self) -> datetime:
         """Latest date and time collection must be completed."""
-        pass
-
 
 
 class Requirement(ABC):
     """Requirement to be satisfied by the planned data acquisition."""
 
     @property
-    def citation(self) -> Citation:
-        """Identification of reference or guidance material for the requirement."""
-        return None
+    @abstractmethod
+    def citation(self) -> Optional[Citation]:
+        """
+        Identification of reference or guidance material for the requirement.
+        """
 
     @property
     @abstractmethod
     def identifier(self) -> Identifier:
         """Unique name, or code, for the requirement."""
-        pass
 
     @property
     @abstractmethod
     def requestor(self) -> Sequence[Responsibility]:
         """Origin of requirement."""
-        pass
 
     @property
     @abstractmethod
     def recipient(self) -> Sequence[Responsibility]:
         """Person(s), or body(ies), to receive results of requirement."""
-        pass
 
     @property
     @abstractmethod
     def priority(self) -> PriorityCode:
         """Relative ordered importance, or urgency, of the requirement."""
-        pass
 
     @property
     @abstractmethod
     def requested_date(self) -> RequestedDate:
         """Required or preferred acquisition date and time."""
-        pass
 
     @property
     @abstractmethod
     def expiry_date(self) -> datetime:
         """Date and time after which collection is no longer valid."""
-        pass
 
     @property
-    def satisfied_plan(self) -> Sequence['Plan']:
-        return None
-
+    @abstractmethod
+    def satisfied_plan(self) -> Optional[Sequence['Plan']]:
+        """Plan that identifies solution to satisfy the requirement."""
 
 
 class Plan(ABC):
-    """Designations for the planning information related to meeting requirements."""
+    """
+    Designations for the planning information related to meeting requirements.
+    """
 
     @property
-    def type(self) -> GeometryTypeCode:
-        """Manner of sampling geometry the planner expects for collection of the objective data."""
-        return None
+    @abstractmethod
+    def type(self) -> Optional[GeometryTypeCode]:
+        """
+        Manner of sampling geometry the planner expects for collection of the
+        objective data.
+        """
 
     @property
     @abstractmethod
     def status(self) -> ProgressCode:
         """Current status of the plan (pending, completed, etc.)."""
-        pass
 
     @property
     @abstractmethod
     def citation(self) -> Citation:
         """Identification of authority requesting target collection."""
-        pass
 
     @property
-    def operation(self) -> Sequence[Operation]:
-        return None
+    @abstractmethod
+    def operation(self) -> Optional[Sequence[Operation]]:
+        """Identification of the activity or activities that satisfy a plan."""
 
     @property
-    def satisfied_requirement(self) -> Sequence[Requirement]:
-        return None
-
+    @abstractmethod
+    def satisfied_requirement(self) -> Optional[Sequence[Requirement]]:
+        """Requirement satisfied by the plan."""
 
 
 class AcquisitionInformation(ABC):
-    """Designations for the measuring instruments and their bands, the platform carrying them, and the mission to which the data contributes."""
+    """
+    Designations for the measuring instruments and their bands, the platform
+    carrying them, and the mission to which the data contributes.
+    """
 
     @property
-    def instrument(self) -> Sequence[Instrument]:
-        return None
+    @abstractmethod
+    def scope(self) -> Optional[Sequence[Scope]]:
+        """The specific data to which the acquisition information applies."""
 
     @property
-    def operation(self) -> Sequence[Operation]:
-        return None
+    @abstractmethod
+    def acquisition_plan(self) -> Optional[Sequence[Plan]]:
+        """Identifies the plan as implemented by the acquisition."""
 
     @property
-    def platform(self) -> Sequence[Platform]:
-        return None
+    @abstractmethod
+    def acquisition_requirement(self) -> Optional[Sequence[Requirement]]:
+        """
+        Identifies the requirement the data acquisition intends to satisfy.
+        """
 
     @property
-    def acquisition_plan(self) -> Sequence[Plan]:
-        return None
+    @abstractmethod
+    def environmental_conditions(self) -> Optional[EnvironmentalRecord]:
+        """
+        A record of the environmental circumstances during the data
+        acquisition.
+        """
 
     @property
-    def objective(self) -> Sequence[Objective]:
-        return None
+    @abstractmethod
+    def instrument(self) -> Optional[Sequence[Instrument]]:
+        """
+        General information about the instrument used in data acquisition.
+        """
 
     @property
-    def acquisition_requirement(self) -> Sequence[Requirement]:
-        return None
+    @abstractmethod
+    def objective(self) -> Optional[Sequence[Objective]]:
+        """Identification of the area or object to be sensed."""
 
     @property
-    def environmental_conditions(self) -> EnvironmentalRecord:
-        return None
+    @abstractmethod
+    def operation(self) -> Optional[Sequence[Operation]]:
+        """
+        General information about an identifiable activity which provided the
+        data.
+        """
+
+    @property
+    @abstractmethod
+    def platform(self) -> Optional[Sequence[Platform]]:
+        """
+        General information about the platform from which the data were taken.
+        """

--- a/geoapi/src/main/python/opengis/metadata/base.py
+++ b/geoapi/src/main/python/opengis/metadata/base.py
@@ -1,15 +1,56 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the base module.
+
+This subpackage contains geographic metadata structures regarding data
+acquisition that are derived from theISO 19115-1:2014 and ISO 19115-2:2019
+international standards.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
+from typing import Optional
 
+from opengis.metadata.acquisition import AcquisitionInformation
+from opengis.metadata.citation import (
+    Citation,
+    Date,
+    Identifier,
+    OnlineResource,
+    Responsibility,
+)
+from opengis.metadata.constraints import Constraints
+from opengis.metadata.content import ContentInformation
+from opengis.metadata.distribution import Distribution
+from opengis.metadata.extension import (
+    ApplicationSchemaInformation,
+    MetadataExtensionInformation,
+)
+from opengis.metadata.identification import Identification
+from opengis.metadata.lineage import Lineage
+from opengis.metadata.maintenance import MaintenanceInformation, ScopeCode
+from opengis.metadata.quality import DataQuality
+from opengis.metadata.representation import SpatialRepresentation
+from opengis.referencing.crs import ReferenceSystem
 
-
-from opengis.metadata.citation import Citation, Identifier, Responsibility, Date, OnlineResource
 
 class PortrayalCatalogueReference(ABC):
     """Information identifying the portrayal catalogue used."""
@@ -18,163 +59,212 @@ class PortrayalCatalogueReference(ABC):
     @abstractmethod
     def portrayal_catalogue_citation(self) -> Sequence[Citation]:
         """Bibliographic reference to the portrayal catalogue cited."""
-        pass
 
-
-
-from opengis.metadata.maintenance import ScopeCode, MaintenanceInformation
 
 class MetadataScope(ABC):
+    """Information about the scope of the resource."""
 
     @property
     @abstractmethod
     def resource_scope(self) -> ScopeCode:
-        pass
+        """Code for the scope. Default = 'dataset'."""
 
     @property
-    def name(self) -> str:
-        return None
+    @abstractmethod
+    def name(self) -> Optional[str]:
+        """Description of the scope."""
 
-
-
-from opengis.metadata.representation import SpatialRepresentation
-from opengis.metadata.extension import MetadataExtensionInformation, ApplicationSchemaInformation
-from opengis.metadata.identification import Identification
-from opengis.metadata.content import ContentInformation
-from opengis.metadata.distribution import Distribution
-from opengis.metadata.quality import DataQuality
-from opengis.metadata.lineage import Lineage
-from opengis.metadata.constraints import Constraints
-from opengis.metadata.acquisition import AcquisitionInformation
-from opengis.referencing.crs import ReferenceSystem
 
 class Metadata(ABC):
     """Root entity which defines metadata about a resource or resources."""
 
     @property
-    def metadata_identifier(self) -> Identifier:
+    @abstractmethod
+    def metadata_identifier(self) -> Optional[Identifier]:
         """Unique identifier for this metadata record."""
-        return None
 
     @property
-    def default_locale(self):
-        """Provides information about an alternatively used localized character string for a linguistic extension."""
-        return None
+    @abstractmethod
+    def default_locale(self) -> Optional[str]:
+        """
+        Language and character set used for documenting metadata.
+        A string conforming to IETF BCP 47.
+
+        MANDATORY: if UTF-8 not used and not defined in encoding.
+        """
 
     @property
-    def parent_metadata(self) -> Citation:
-        """Identifier and onlineResource for a parent metadata record."""
-        return None
+    @abstractmethod
+    def parent_metadata(self) -> Optional[Citation]:
+        """
+        Identification of the parent metadata record.
 
-    @property
-    def metadata_scope(self) -> Sequence[MetadataScope]:
-        """The scope or type of resource for which metadata is provided."""
-        return None
+        MANDATORY: if there is an upper level object.
+        """
 
     @property
     @abstractmethod
     def contact(self) -> Sequence[Responsibility]:
         """Party responsible for the metadata information."""
-        pass
 
     @property
     @abstractmethod
     def date_info(self) -> Sequence[Date]:
-        """Date(s) other than creation date. Example: expiry date."""
-        pass
+        """
+        Date(s) associated with the metadata.
+
+        NOTE: 'Creation' date must be provided, others can also be provided.
+        """
 
     @property
-    def metadata_standard(self) -> Sequence[Citation]:
-        """Citation for the standards to which the metadata conforms."""
-        return None
+    @abstractmethod
+    def metadata_standard(self) -> Optional[Sequence[Citation]]:
+        """
+        Citation for the standards to which the metadata conforms.
+
+        NOTE: Metadata standard citations should include an identifier.
+        """
 
     @property
-    def metadata_profile(self) -> Sequence[Citation]:
-        """Citation(s) for the profile(s) of the metadata standard to which the metadata conform."""
-        return None
+    @abstractmethod
+    def metadata_profile(self) -> Optional[Sequence[Citation]]:
+        """
+        Citation(s) for the profile(s) of the metadata standard to which the
+        metadata conform.
+
+        NOTE: Metadata citations should include an identifier.
+        """
 
     @property
-    def alternative_metadata_reference(self) -> Sequence[Citation]:
-        """Unique Identifier and onlineResource for alternative metadata."""
-        return None
+    @abstractmethod
+    def alternative_metadata_reference(self) -> Optional[Sequence[Citation]]:
+        """
+        Reference to alternative metadata,e.g., Dublin Core, FGDC, or metadata
+        in a non-ISO standard for the same resource.
+        """
 
     @property
-    def metadata_linkage(self) -> Sequence[OnlineResource]:
+    @abstractmethod
+    def other_locale(self) -> Optional[Sequence[str]]:
+        """
+        Provides information about an alternatively used localized character
+        strings. A string conforming to IETF BCP 47.
+        """
+
+    @property
+    @abstractmethod
+    def metadata_linkage(self) -> Optional[Sequence[OnlineResource]]:
         """Online location where the metadata is available."""
-        return None
 
     @property
-    def spatial_representation_info(self) -> Sequence[SpatialRepresentation]:
+    @abstractmethod
+    def spatial_representation_info(self) -> Optional[Sequence[
+        SpatialRepresentation
+    ]]:
         """Digital representation of spatial information in the dataset."""
-        return None
 
     @property
-    def reference_system_info(self) -> Sequence[ReferenceSystem]:
+    @abstractmethod
+    def reference_system_info(self) -> Optional[Sequence[ReferenceSystem]]:
         """
-        Description of the spatial and temporal reference systems used in the dataset.
+        Description of the spatial and temporal reference systems used in
+        the dataset.
+
         The reference system may be:
-
-        * An ISO 19111 object such as ``CoordinateReferenceSystem``.
-        * A ``ReferenceSystem`` with the ``identifier`` property (from ISO 19111) sets to a list of ``Identifier`` values such as ``["EPSG::4326"]``.
-        * An object with the ``referenceSystemIdentifier`` property (from ISO 19115) sets to a single ``Identifier`` value such as ``"EPSG::4326"``,
-          optionally with a ``referenceSystemType`` property sets to a value such as ``geodeticGeographic2D`` or ``compoundProjectedTemporal``.
-
-        :rtype: Sequence[ReferenceSystem]
+        - An ISO 19111 object such as `CoordinateReferenceSystem`.
+        - A `ReferenceSystem` with the `identifier` property (from
+            ISO 19111) sets to a list of `Identifier` values such as
+            `["EPSG::4326"]`.
+        - An object with the `referenceSystemIdentifier` property (from
+            ISO 19115) sets to a single `Identifier` value such as
+                `"EPSG::4326"`,
+        The ReferenceSystem object may optionally have a
+            `reference_system_type_code` property set to a value such as
+            `geodeticGeographic2D` or `compoundProjectedTemporal`.
         """
-        return None
 
     @property
-    def metadata_extension_info(self) -> Sequence[MetadataExtensionInformation]:
+    @abstractmethod
+    def metadata_extension_info(self) -> Optional[Sequence[
+        MetadataExtensionInformation
+    ]]:
         """Information describing metadata extensions."""
-        return None
 
     @property
     @abstractmethod
     def identification_info(self) -> Sequence[Identification]:
-        """Basic information about the resource(s) to which the metadata applies."""
-        pass
+        """
+        Basic information about the resource(s) to which the metadata applies.
+        """
 
     @property
-    def content_info(self) -> Sequence[ContentInformation]:
+    @abstractmethod
+    def content_info(self) -> Optional[Sequence[ContentInformation]]:
         """Information about the feature and coverage characteristics."""
-        return None
 
     @property
-    def distribution_info(self) -> Sequence[Distribution]:
-        """Information about the distributor of and options for obtaining the resource(s)."""
-        return None
+    @abstractmethod
+    def distribution_info(self) -> Optional[Sequence[Distribution]]:
+        """
+        Information about the distributor of and options for obtaining the
+        resource(s).
+        """
 
     @property
-    def data_quality_info(self) -> Sequence[DataQuality]:
+    @abstractmethod
+    def data_quality_info(self) -> Optional[Sequence[DataQuality]]:
         """Overall assessment of quality of a resource(s)."""
-        return None
 
     @property
-    def resource_lineage(self) -> Sequence[Lineage]:
-        """Information about the provenance, sources and/or the production processes applied to the resource."""
-        return None
+    @abstractmethod
+    def portrayal_catalogue_info(self) -> Optional[Sequence[
+        PortrayalCatalogueReference
+    ]]:
+        """
+        Information about the catalogue of rules defined for the portrayal of
+        a resource(s).
+        """
 
     @property
-    def portrayal_catalogue_info(self) -> Sequence[PortrayalCatalogueReference]:
-        """Information about the catalogue of rules defined for the portrayal of a resource(s)."""
-        return None
-
-    @property
-    def metadata_constraints(self) -> Sequence[Constraints]:
+    @abstractmethod
+    def metadata_constraints(self) -> Optional[Sequence[Constraints]]:
         """Restrictions on the access and use of metadata."""
-        return None
 
     @property
-    def application_schema_info(self) -> Sequence[ApplicationSchemaInformation]:
+    @abstractmethod
+    def application_schema_info(self) -> Optional[Sequence[
+        ApplicationSchemaInformation
+    ]]:
         """Information about the conceptual schema of a dataset."""
-        return None
 
     @property
-    def metadata_maintenance(self) -> MaintenanceInformation:
-        """Information about the frequency of metadata updates, and the scope of those updates."""
-        return None
+    @abstractmethod
+    def metadata_maintenance(self) -> Optional[MaintenanceInformation]:
+        """
+        Information about the frequency of metadata updates, and the scope of
+        those updates.
+        """
 
     @property
-    def acquisition_information(self) -> Sequence[AcquisitionInformation]:
+    @abstractmethod
+    def resource_lineage(self) -> Optional[Sequence[Lineage]]:
+        """
+        Information about the provenance, sources and/or the production
+        processes applied to the resource.
+        """
+
+    @property
+    @abstractmethod
+    def metadata_scope(self) -> Optional[Sequence[MetadataScope]]:
+        """
+        The scope or type of resource for which metadata is provided.
+
+        MANDATORY: if `Metadata` is about a resource other than a dataset.
+        """
+
+    @property
+    @abstractmethod
+    def acquisition_information(self) -> Optional[
+        Sequence[AcquisitionInformation]
+    ]:
         """Information about the acquisition of the data."""
-        return None

--- a/geoapi/src/main/python/opengis/metadata/citation.py
+++ b/geoapi/src/main/python/opengis/metadata/citation.py
@@ -1,270 +1,579 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the citation module.
+
+This module contains geographic metadata structures regarding metadata
+citations derived from the ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import datetime
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.extent import Extent
+from opengis.metadata.identification import BrowseGraphic
 
 
 class DateTypeCode(Enum):
-    CREATION = "creation"
-    PUBLICATION = "publication"
-    REVISION = "revision"
-    EXPIRY = "expiry"
-    LAST_UPDATE = "lastUpdate"
-    LAST_REVISION = "lastRevision"
-    NEXT_UPDATE = "nextUpdate"
-    UNAVAILABLE = "unavailable"
-    IN_FORCE = "inForce"
-    ADOPTED = "adopted"
-    DEPRECATED = "deprecated"
-    SUPERSEDED = "superseded"
-    VALIDITY_BEGINS = "validityBegins"
-    VALIDITY_EXPIRES = "validityExpires"
-    RELEASED = "released"
-    DISTRIBUTION = "distribution"
+    """Identification of when a given event occurred."""
 
+    CREATION = "creation"
+    """Date identifies when the resource was brought into existence."""
+
+    PUBLICATION = "publication"
+    """Date identifies when the resource was issued."""
+
+    REVISION = "revision"
+    """
+    Date identifies when the resource was examined or rexamined and improved
+    or amended.
+    """
+
+    EXPIRY = "expiry"
+    """Date identifies when resource expires."""
+
+    LAST_UPDATE = "lastUpdate"
+    """Date identifies when resource was last updated."""
+
+    LAST_REVISION = "lastRevision"
+    """Date identifies when resource was last reviewed."""
+
+    NEXT_UPDATE = "nextUpdate"
+    """Date identifies when resource will be next updated."""
+
+    UNAVAILABLE = "unavailable"
+    """Date identifies when resource became not available or obtainable."""
+
+    IN_FORCE = "inForce"
+    """Date identifies when resource became in force."""
+
+    ADOPTED = "adopted"
+    """Date identifies when resource was adopted."""
+
+    DEPRECATED = "deprecated"
+    """Date identifies when resource was deprecated."""
+
+    SUPERSEDED = "superseded"
+    """
+    Date identifies when resource was superceded or replaced by another
+    resource.
+    """
+
+    VALIDITY_BEGINS = "validityBegins"
+    """
+    Time at which the data are considered to become valid.
+
+    NOTE: There could be quite a delay between creation and validity begins.
+    """
+
+    VALIDITY_EXPIRES = "validityExpires"
+    """Time at which the data are no longer considered to be valid."""
+
+    RELEASED = "released"
+    """The date that the resource shall be released for public access."""
+
+    DISTRIBUTION = "distribution"
+    """Date identifies when an instance of the resource was distributed."""
 
 
 class OnLineFunctionCode(Enum):
-    DOWNLOAD = "download"
-    INFORMATION = "information"
-    OFFLINE_ACCESS = "offlineAccess"
-    ORDER = "order"
-    SEARCH = "search"
-    COMPLETE_METADATA = "completeMetadata"
-    BROWSE_GRAPHIC = "browseGraphic"
-    UPLOAD = "upload"
-    EMAIL_SERVICE = "emailService"
-    BROWSING = "browsing"
-    FILE_ACCESS = "fileAccess"
+    """Function performed by the resource."""
 
+    DOWNLOAD = "download"
+    """
+    Online instructions for transferring data from one storage device or
+    system to another.
+    """
+    INFORMATION = "information"
+    """Online information about the resource."""
+
+    OFFLINE_ACCESS = "offlineAccess"
+    """Online instructions for requesting the resource from the provider."""
+
+    ORDER = "order"
+    """Online order process for obtaining the resource."""
+
+    SEARCH = "search"
+    """
+    Online search interface for seeking out information about the resource.
+    """
+
+    COMPLETE_METADATA = "completeMetadata"
+    """Complete metadata provided."""
+
+    BROWSE_GRAPHIC = "browseGraphic"
+    """Browse graphic provided."""
+
+    UPLOAD = "upload"
+    """Online resource upload capability provided."""
+
+    EMAIL_SERVICE = "emailService"
+    """Online email service provided."""
+
+    BROWSING = "browsing"
+    """Online browsing provided."""
+
+    FILE_ACCESS = "fileAccess"
+    """Online file access provided."""
 
 
 class PresentationFormCode(Enum):
-    DOCUMENT_DIGITAL = "documentDigital"
-    DOCUMENT_HARDCOPY = "documentHardcopy"
-    IMAGE_DIGITAL = "imageDigital"
-    IMAGE_HARDCOPY = "imageHardcopy"
-    MAP_DIGITAL = "mapDigital"
-    MAP_HARDCOPY = "mapHardcopy"
-    MODEL_DIGITAL = "modelDigital"
-    MODEL_HARDCOPY = "modelHardcopy"
-    PROFILE_DIGITAL = "profileDigital"
-    PROFILE_HARDCOPY = "profileHardcopy"
-    TABLE_DIGITAL = "tableDigital"
-    TABLE_HARDCOPY = "tableHardcopy"
-    VIDEO_DIGITAL = "videoDigital"
-    VIDEO_HARDCOPY = "videoHardcopy"
-    AUDIO_DIGITAL = "audioDigital"
-    AUDIO_HARDCOPY = "audioHardcopy"
-    MULTIMEDIA_DIGITAL = "multimediaDigital"
-    MULTIMEDIA_HARDCOPY = "multimediaHardcopy"
-    PHYSICAL_OBJECT = "physicalObject"
-    DIAGRAM_DIGITAL = "diagramDigital"
-    DIAGRAM_HARDCOPY = "diagramHardcopy"
+    """Mode in which the data are represented."""
 
+    DOCUMENT_DIGITAL = "documentDigital"
+    """
+    Digital representation of a primarily textual item (can contain
+    illustrations also).
+    """
+
+    DOCUMENT_HARDCOPY = "documentHardcopy"
+    """
+    Representaiton of a primarily textual item (can contain illustrations
+    also) on paper, photographic material, or other media.
+    """
+
+    IMAGE_DIGITAL = "imageDigital"
+    """
+    Likeness of natural or man-made features, objects, and activities acquired
+    through the sensing of visual or any other segment of the electronic
+    spectrum by sensors, such as thermal infrared and high resolution radar,
+    and stored in digital format.
+    """
+
+    IMAGE_HARDCOPY = "imageHardcopy"
+    """
+    Likeness of natural or man-made features, objects, and activities acquired
+    through the sensing of visual or any other segment of the electronic
+    spectrum by sensors, such as thermal infrared and high resolution radar,
+    and stored on paper, photographic material, or other media for use
+    directly by the human user.
+    """
+
+    MAP_DIGITAL = "mapDigital"
+    """Map represented in raster or vector form."""
+
+    MAP_HARDCOPY = "mapHardcopy"
+    """
+    Map printed on paper, photographic material, or other media for use
+    directly by the human user.
+    """
+
+    MODEL_DIGITAL = "modelDigital"
+    """Multi-dimensional digital representation of a feature, process, etc."""
+
+    MODEL_HARDCOPY = "modelHardcopy"
+    """3-dimensional, physical model."""
+
+    PROFILE_DIGITAL = "profileDigital"
+    """Vertical cross-section in digital form."""
+
+    PROFILE_HARDCOPY = "profileHardcopy"
+    """Vertical cross-section on paper, etc."""
+
+    TABLE_DIGITAL = "tableDigital"
+    """"
+    Digital representation of facts or figures systematically displayed,
+    especially in columns.
+    """
+
+    TABLE_HARDCOPY = "tableHardcopy"
+    """"
+    Representation of facts or figures systematically displayed, especially in
+    columns, printed on paper, photographic material, or other media.
+    """
+
+    VIDEO_DIGITAL = "videoDigital"
+    """Digital video recording."""
+
+    VIDEO_HARDCOPY = "videoHardcopy"
+    """Video recording on film."""
+
+    AUDIO_DIGITAL = "audioDigital"
+    """Digital audio recording."""
+
+    AUDIO_HARDCOPY = "audioHardcopy"
+    """Audio recroding delivered by analog media, such as a magnetic tape."""
+
+    MULTIMEDIA_DIGITAL = "multimediaDigital"
+    """
+    Information representation using simultaneously various digital modes
+    text, sound, image.
+    """
+
+    MULTIMEDIA_HARDCOPY = "multimediaHardcopy"
+    """
+    Information representation using simultaneously various analog modes
+    text, sound, image.
+    """
+
+    PHYSICAL_OBJECT = "physicalObject"
+    """
+    A physical object.
+
+    EXAMPLE: Rock or mineral sample, microscope slide.
+    """
+
+    DIAGRAM_DIGITAL = "diagramDigital"
+    """
+    Information represented graphically by charts such as pie chart,
+    bar chart, and other type of diagrms and recorded in digital format.
+    """
+
+    DIAGRAM_HARDCOPY = "diagramHardcopy"
+    """
+    Information represented graphically by charts such as pie chart,
+    bar chart, and other type of diagrams and printed on paper, photographic
+    material, or other media.
+    """
 
 
 class RoleCode(Enum):
-    RESOURCE_PROVIDER = "resourceProvider"
-    CUSTODIAN = "custodian"
-    OWNER = "owner"
-    USER = "user"
-    DISTRIBUTOR = "distributor"
-    ORIGINATOR = "originator"
-    POINT_OF_CONTACT = "pointOfContact"
-    PRINCIPAL_INVESTIGATOR = "principalInvestigator"
-    PROCESSOR = "processor"
-    PUBLISHER = "publisher"
-    AUTHOR = "author"
-    SPONSOR = "sponsor"
-    CO_AUTHOR = "coAuthor"
-    COLLABORATOR = "collaborator"
-    EDITOR = "editor"
-    MEDIATOR = "mediator"
-    RIGHTS_HOLDER = "rightsHolder"
-    CONTRIBUTOR = "contributor"
-    FUNDER = "funder"
-    STAKEHOLDER = "stakeholder"
+    """Function performed by the responsible party."""
 
+    RESOURCE_PROVIDER = "resourceProvider"
+    """Party that supplies the resource."""
+
+    CUSTODIAN = "custodian"
+    """
+    Party that accepts accountability and responsibility for the resource and
+    ensures appropriate care an maintenance of the resource.
+    """
+
+    OWNER = "owner"
+    """Party that owns the resource."""
+
+    USER = "user"
+    """Party who uses the resource."""
+
+    DISTRIBUTOR = "distributor"
+    """Party who distributes the resource."""
+
+    ORIGINATOR = "originator"
+    """Party who created the resource."""
+
+    POINT_OF_CONTACT = "pointOfContact"
+    """
+    Party who can be contactedfor acquiring knowledge about or acquisition of
+    the resource.
+    """
+
+    PRINCIPAL_INVESTIGATOR = "principalInvestigator"
+    """
+    Key party responsible for gathering information and conducting research.
+    """
+
+    PROCESSOR = "processor"
+    """
+    Party who has processed the data in a manner such that the resource has
+    been modified.
+    """
+
+    PUBLISHER = "publisher"
+    """Party who published resource."""
+
+    AUTHOR = "author"
+    """Party who authored the resource."""
+
+    SPONSOR = "sponsor"
+    """Party who speaks for the resource."""
+
+    CO_AUTHOR = "coAuthor"
+    """Party who jointly authors the resource."""
+
+    COLLABORATOR = "collaborator"
+    """
+    Party who assists with the generation of the resource other than the
+    principal investigator.
+    """
+
+    EDITOR = "editor"
+    """
+    Party who reviewed or modified the resource to improve the content.
+    """
+
+    MEDIATOR = "mediator"
+    """
+    A class of entity that mediates access to the resource and for whom the
+    resource is intended or useful.
+    """
+
+    RIGHTS_HOLDER = "rightsHolder"
+    """Party owning or managing the rights over the resource."""
+
+    CONTRIBUTOR = "contributor"
+    """Party contributing to the resource."""
+
+    FUNDER = "funder"
+    """Party providing monetary support for the resource."""
+
+    STAKEHOLDER = "stakeholder"
+    """Party who has an interest in the resource or the use of the resource."""
 
 
 class TelephoneTypeCode(Enum):
-    VOICE = "voice"
-    FACSIMILE = "facsimile"
-    SMS = "sms"
+    """Type of telephone."""
 
+    VOICE = "voice"
+    """Telephone provides voice service."""
+
+    FACSIMILE = "facsimile"
+    """Telephone provides facsimile service."""
+
+    SMS = "sms"
+    """Telephone provides sms service."""
 
 
 class Series(ABC):
-    """Information about the series, or aggregate resource, to which a resource belongs."""
+    """
+    Information about the series, or aggregate resource, to which a resource
+    belongs.
+    """
 
     @property
-    def name(self) -> str:
-        """Name of the series, or aggregate resource, of which the resource is a part."""
-        return None
+    @abstractmethod
+    def name(self) -> Optional[str]:
+        """
+        Name of the series, or aggregate resource, of which the resource is a
+        part.
+        """
 
     @property
-    def issue_identification(self) -> str:
+    @abstractmethod
+    def issue_identification(self) -> Optional[str]:
         """Information identifying the issue of the series."""
-        return None
 
     @property
-    def page(self) -> str:
-        """Details on which pages of the publication the article was published."""
-        return None
-
+    @abstractmethod
+    def page(self) -> Optional[str]:
+        """
+        Details on which pages of the publication the article was published.
+        """
 
 
 class Address(ABC):
     """Location of the responsible individual or organisation."""
 
     @property
-    def delivery_point(self) -> Sequence[str]:
-        """Address line for the location (as described in ISO 11180, Annex A)."""
-        return None
+    @abstractmethod
+    def delivery_point(self) -> Optional[Sequence[str]]:
+        """
+        Address line for the location (as described in ISO 11180, Annex A).
+        """
 
     @property
-    def city(self) -> str:
+    @abstractmethod
+    def city(self) -> Optional[str]:
         """City of the location."""
-        return None
 
     @property
-    def administrative_area(self) -> str:
+    @abstractmethod
+    def administrative_area(self) -> Optional[str]:
         """State, province of the location."""
-        return None
 
     @property
-    def postal_code(self) -> str:
+    @abstractmethod
+    def postal_code(self) -> Optional[str]:
         """ZIP or other postal code."""
-        return None
 
     @property
-    def country(self) -> str:
+    @abstractmethod
+    def country(self) -> Optional[str]:
         """Country of the physical address."""
-        return None
 
     @property
-    def electronic_mail_address(self) -> Sequence[str]:
-        """Address of the electronic mailbox of the responsible organisation or individual."""
-        return None
-
+    @abstractmethod
+    def electronic_mail_address(self) -> Optional[Sequence[str]]:
+        """
+        Address of the electronic mailbox of the responsible organisation or
+        individual.
+        """
 
 
 class Telephone(ABC):
-    """Telephone numbers for contacting the responsible individual or organisation."""
+    """
+    Telephone numbers for contacting the responsible individual or
+    organisation.
+    """
 
     @property
     @abstractmethod
     def number(self) -> str:
-        """Telephone number by which individuals can contact responsible organisation or individual."""
-        pass
-
-    @property
-    def number_type(self) -> TelephoneTypeCode:
-        """Type of telephone responsible organisation or individual."""
-        return None
-
-
-
-class OnlineResource(ABC):
-    """Information about on-line sources from which the resource, specification, or community profile name and extended metadata elements can be obtained."""
+        """
+        Telephone number by which individuals can contact responsible
+        organisation or individual.
+        """
 
     @property
     @abstractmethod
-    def linkage(self):
-        """Location (address) for on-line access using a Uniform Resource Locator/Uniform Resource Identifier address or similar addressing scheme such as http://www.statkart.no/isotc211."""
-        pass
+    def number_type(self) -> Optional[TelephoneTypeCode]:
+        """Type of telephone responsible organisation or individual."""
+
+
+class OnlineResource(ABC):
+    """
+    Information about on-line sources from which the resource, specification,
+    or community profile name and extended metadata elements can be obtained.
+    """
 
     @property
-    def protocol(self) -> str:
+    @abstractmethod
+    def linkage(self) -> str:
+        """
+        Location (address) for on-line access using a Uniform Resource Locator/
+        Uniform Resource Identifier address or similar addressing scheme such
+        as http://www.statkart.no/isotc211.
+        """
+
+    @property
+    @abstractmethod
+    def protocol(self) -> Optional[str]:
         """Connection protocol to be used e.g. http, ftp, file."""
-        return None
 
     @property
-    def application_profile(self) -> str:
-        """Name of an application profile that can be used with the online resource."""
-        return None
+    @abstractmethod
+    def application_profile(self) -> Optional[str]:
+        """
+        Name of an application profile that can be used with the online
+        resource.
+        """
 
     @property
-    def name(self) -> str:
+    @abstractmethod
+    def name(self) -> Optional[str]:
         """Name of the online resource."""
-        return None
 
     @property
-    def description(self) -> str:
+    @abstractmethod
+    def description(self) -> Optional[str]:
         """Detailed text description of what the online resource is/does."""
-        return None
 
     @property
-    def function(self) -> OnLineFunctionCode:
+    @abstractmethod
+    def function(self) -> Optional[OnLineFunctionCode]:
         """Code for function performed by the online resource."""
-        return None
 
     @property
-    def protocol_request(self) -> str:
-        """Protocol used by the accessed resource."""
-        return None
+    @abstractmethod
+    def protocol_request(self) -> Optional[str]:
+        """
+        Request used to access the resource depending on the protocol
+        (to be used mainly for POST requests)
 
+        Protocol used by the accessed resource.
+
+        Example POST/XML:
+
+        ```
+        <Ge tFeatures service = "WFS"
+                     version="2.0.0"
+                     outputFormat="application/gml+xml; version=3.2"
+                     xmlns=http://www.opengis.net/wfs/2.0
+                     xmlns:xsi=http://www.w3.org/2001/XMLSchema-instance
+                     xsi:schemaLocation="http://www.opengis.net/wfs/2.0
+                        http://schemas.opengis.net/wfs/2.0.0/wfs.xsd">
+        <Query typeNames="Roads" />
+        </GetFeatures>
+        ```
+        """
 
 
 class Contact(ABC):
-    """Information required to enable contact with the responsible person and/or organisation."""
+    """
+    Information required to enable contact with the responsible person and/or
+    organisation.
+    """
 
     @property
-    def phone(self) -> Sequence[Telephone]:
-        """Telephone numbers at which the organisation or individual may be contacted."""
-        return None
+    @abstractmethod
+    def phone(self) -> Optional[Sequence[Telephone]]:
+        """
+        Telephone numbers at which the organisation or individual may be
+        contacted.
+        """
 
     @property
-    def address(self) -> Sequence[Address]:
-        """Physical and email address at which the organisation or individual may be contacted."""
-        return None
+    @abstractmethod
+    def address(self) -> Optional[Sequence[Address]]:
+        """
+        Physical and email address at which the organisation or individual may
+        be contacted.
+        """
 
     @property
-    def online_resource(self) -> Sequence[OnlineResource]:
-        """On-line information that can be used to contact the individual or organisation."""
-        return None
+    @abstractmethod
+    def online_resource(self) -> Optional[Sequence[OnlineResource]]:
+        """
+        On-line information that can be used to contact the individual or
+        organisation.
+        """
 
     @property
-    def hours_of_service(self) -> Sequence[str]:
-        """Time period (including time zone) when individuals can contact the organisation or individual."""
-        return None
+    @abstractmethod
+    def hours_of_service(self) -> Optional[Sequence[str]]:
+        """
+        Time period (including time zone) when individuals can contact the
+        organisation or individual.
+        """
 
     @property
-    def contact_instructions(self) -> str:
-        """Supplemental instructions on how or when to contact the individual or organisation."""
-        return None
+    @abstractmethod
+    def contact_instructions(self) -> Optional[str]:
+        """
+        Supplemental instructions on how or when to contact the individual or
+        organisation.
+        """
 
     @property
-    def contact_type(self) -> str:
-        return None
-
+    @abstractmethod
+    def contact_type(self) -> Optional[str]:
+        """Type of the contact."""
 
 
 class Party(ABC):
     """Information about the individual and/or organisation of the party."""
 
     @property
-    def name(self) -> str:
-        """Name of the party."""
-        return None
+    @abstractmethod
+    def name(self) -> Optional[str]:
+        """
+        Name of the party.
+
+        MANDATORY: if `logo` and `position_name`are `None`.
+        """
 
     @property
+    @abstractmethod
     def contact_info(self) -> Sequence[Contact]:
         """Contact information for the party."""
-        return None
 
     @property
-    def party_identifier(self) -> Sequence['Identifier']:
-        """Identifier of the party."""
-        return None
+    @abstractmethod
+    def party_identifier(self) -> Optional[Sequence['Identifier']]:
+        """
+        Identifier of the party.
 
+        MANDATORY: if `name` and `logo` are `None`.
+        """
 
 
 class Responsibility(ABC):
@@ -274,45 +583,48 @@ class Responsibility(ABC):
     @abstractmethod
     def role(self) -> RoleCode:
         """Function performed by the responsible party."""
-        pass
 
     @property
-    def extent(self) -> Sequence['Extent']:
+    @abstractmethod
+    def extent(self) -> Optional[Sequence[Extent]]:
         """Spatial or temporal extent of the role."""
-        return None
 
     @property
     @abstractmethod
     def party(self) -> Sequence[Party]:
-        pass
-
+        """Information about the Party."""
 
 
 class Individual(Party):
     """Information about the party if the party is an individual."""
 
     @property
-    def position_name(self) -> str:
-        """Position of the individual in an organisation."""
-        return None
+    @abstractmethod
+    def position_name(self) -> Optional[str]:
+        """
+        Position of the individual in an organisation.
 
+        MANDATORY: if `name` and `logo` are `None`.
+        """
 
 
 class Organisation(Party):
     """Information about the party if the party is an organisation."""
 
     @property
-    def logo(self) -> Sequence['BrowseGraphic']:
-        """Graphic identifying organization."""
-        return None
+    @abstractmethod
+    def logo(self) -> Sequence[BrowseGraphic]:
+        """
+        Graphic identifying organisation.
+
+        MANDATORY: if `name` and `position_name`are `None`.
+        """
 
     @property
-    def individual(self) -> Sequence[Individual]:
-        return None
+    @abstractmethod
+    def individual(self) -> Optional[Sequence[Individual]]:
+        """Individuals belonging to the Organisation."""
 
-
-
-from datetime import datetime
 
 class Date(ABC):
     """Reference date and event used to describe it."""
@@ -321,14 +633,11 @@ class Date(ABC):
     @abstractmethod
     def date(self) -> datetime:
         """Reference date for the cited resource."""
-        pass
 
     @property
     @abstractmethod
     def date_type(self) -> DateTypeCode:
         """Event used for reference date."""
-        pass
-
 
 
 class Citation(ABC):
@@ -338,100 +647,127 @@ class Citation(ABC):
     @abstractmethod
     def title(self) -> str:
         """Name by which the cited resource is known."""
-        pass
 
     @property
-    def alternate_title(self) -> Sequence[str]:
-        """Short name or other language name by which the cited information is known. Example: DCW as an alternative title for Digital Chart of the World."""
-        return None
+    @abstractmethod
+    def alternate_title(self) -> Optional[Sequence[str]]:
+        """
+        Short name or other language name by which the cited information is
+        known.
+
+        Example: 'DCW' as an alternative title for Digital Chart of the
+        World.
+        """
 
     @property
-    def date(self) -> Sequence[Date]:
+    @abstractmethod
+    def date(self) -> Optional[Sequence[Date]]:
         """Reference date for the cited resource."""
-        return None
 
     @property
-    def edition(self) -> str:
+    @abstractmethod
+    def edition(self) -> Optional[str]:
         """Version of the cited resource."""
-        return None
 
     @property
-    def edition_date(self) -> datetime:
+    @abstractmethod
+    def edition_date(self) -> Optional[datetime]:
         """Date of the edition."""
-        return None
 
     @property
-    def identifier(self) -> Sequence['Identifier']:
+    @abstractmethod
+    def identifier(self) -> Optional[Sequence['Identifier']]:
         """Value uniquely identifying an object within a namespace."""
-        return None
 
     @property
-    def cited_responsible_party(self) -> Sequence[Responsibility]:
-        """Name and position information for an individual or organisation that is responsible for the resource."""
-        return None
+    @abstractmethod
+    def cited_responsible_party(self) -> Optional[Sequence[Responsibility]]:
+        """
+        Name and position information for an individual or organisation that
+        is responsible for the resource.
+        """
 
     @property
-    def presentation_form(self) -> Sequence[PresentationFormCode]:
+    @abstractmethod
+    def presentation_form(self) -> Optional[Sequence[PresentationFormCode]]:
         """Mode in which the resource is represented."""
-        return None
 
     @property
-    def series(self) -> Series:
-        """Information about the series, or aggregate resource, of which the resource is a part."""
-        return None
+    @abstractmethod
+    def series(self) -> Optional[Series]:
+        """
+        Information about the series, or aggregate resource, of which the
+        resource is a part.
+        """
 
     @property
-    def other_citation_details(self) -> Sequence[str]:
-        """Other information required to complete the citation that is not recorded elsewhere."""
-        return None
+    @abstractmethod
+    def other_citation_details(self) -> Optional[Sequence[str]]:
+        """
+        Other information required to complete the citation that is not
+        recorded elsewhere.
+        """
 
     @property
-    def ISBN(self) -> str:
+    @abstractmethod
+    def isbn(self) -> Optional[str]:
         """International Standard Book Number."""
-        return None
 
     @property
-    def ISSN(self) -> str:
+    @abstractmethod
+    def issn(self) -> Optional[str]:
         """International Standard Serial Number."""
-        return None
 
     @property
-    def online_resource(self) -> Sequence[OnlineResource]:
+    @abstractmethod
+    def online_resource(self) -> Optional[Sequence[OnlineResource]]:
         """Online reference to the cited resource."""
-        return None
 
     @property
-    def graphic(self) -> Sequence['BrowseGraphic']:
+    @abstractmethod
+    def graphic(self) -> Optional[Sequence['BrowseGraphic']]:
         """Citation graphic or logo for cited party."""
-        return None
-
 
 
 class Identifier(ABC):
     """Value uniquely identifying an object within a namespace."""
 
     @property
-    def authority(self) -> Citation:
-        """Citation for the code namespace and optionally the person or party responsible for maintenance of that namespace."""
-        return None
+    @abstractmethod
+    def authority(self) -> Optional[Citation]:
+        """
+        The person or party responsible for maintenance of the namespace.
+
+        Citation for the code namespace and optionally the person or party
+        responsible for maintenance of that namespace.
+        """
 
     @property
     @abstractmethod
     def code(self) -> str:
-        """Alphanumeric value identifying an instance in the namespace e.g. EPSG::4326."""
-        pass
+        """
+        Alphanumeric value identifying an instance in the namespace.
+
+        NOTE: Avoid characters that are not legal in URLs.
+
+        Example: EPSG::4326.
+        """
 
     @property
-    def code_space(self) -> str:
+    @abstractmethod
+    def code_space(self) -> Optional[str]:
         """Identifier or namespace in which the code is valid."""
-        return None
 
     @property
-    def version(self) -> str:
+    @abstractmethod
+    def version(self) -> Optional[str]:
         """Version identifier for the namespace."""
-        return None
 
     @property
-    def description(self) -> str:
-        """Natural language description of the meaning of the code value E.G for codeSpace = EPSG, code = 4326: description = WGS-84" to "for codeSpace = EPSG, code = EPSG::4326: description = WGS-84."""
-        return None
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """
+        Natural language description of the meaning of the code value.
+
+        Example: for code_space = EPSG, code = 4326, description = WGS-84.
+        """

--- a/geoapi/src/main/python/opengis/metadata/constraints.py
+++ b/geoapi/src/main/python/opengis/metadata/constraints.py
@@ -1,148 +1,314 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the constraints module.
+
+This module contains geographic metadata structures regarding data constraints
+derived from the ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import (
+    Citation,
+    Responsibility,
+)
+from opengis.metadata.identification import BrowseGraphic
+from opengis.metadata.maintenance import Scope
 
 
 class ClassificationCode(Enum):
-    UNCLASSIFIED = "unclassified"
-    RESTRICTED = "restricted"
-    CONFIDENTIAL = "confidential"
-    SECRET = "secret"
-    TOP_SECRET = "topSecret"
-    SENSITIVE_BUT_UNCLASSIFIED = "sensitiveButUnclassified"
-    FOR_OFFICIAL_USE_ONLY = "forOfficialUseOnly"
-    PROTECTED = "protected"
-    LIMITED_DISTRIBUTION = "limitedDistribution"
+    """Name of the handling restrictions on the resource."""
 
+    UNCLASSIFIED = "unclassified"
+    """Available for general disclosure."""
+
+    RESTRICTED = "restricted"
+    """Not for general disclosure."""
+
+    CONFIDENTIAL = "confidential"
+    """Available for someone who can be entrusted with information."""
+
+    SECRET = "secret"
+    """
+    Kept or meant to be kept private, unknown, or hidden from all but a select
+    group of people.
+    """
+
+    TOP_SECRET = "topSecret"
+    """Of the highest secrecy."""
+
+    SENSITIVE_BUT_UNCLASSIFIED = "sensitiveButUnclassified"
+    """
+    Although unclassified, requries strict controls over its distribution.
+    """
+
+    FOR_OFFICIAL_USE_ONLY = "forOfficialUseOnly"
+    """
+    Unclassified information that is to be used only for official purposes
+    determined by the designating body.
+    """
+
+    PROTECTED = "protected"
+    """Compromise of the information could cause damage."""
+
+    LIMITED_DISTRIBUTION = "limitedDistribution"
+    """Destination limited by designating body."""
 
 
 class RestrictionCode(Enum):
+    """Limitation(s) placed upon the access or use of the data."""
+
     COPYRIGHT = "copyright"
+    """
+    Exclusive right tot he publication, production, or sale of the rights to a
+    literary, dramatic, musical, or artistic work, or to the use of a
+    commercial print or label, granted by law for a specified period of time
+    to an author, composer, artist, distributor.
+    """
+
     PATENT = "patent"
+    """
+    Government has granted exclusive right to make, sell, use or license an
+    invention or discovery.
+    """
+
     PATENT_PENDING = "patentPending"
+    """Produced or sold information awaiting a patent."""
+
     TRADEMARK = "trademark"
+    """
+    A name, symbol, or other device identifying a product, officially
+    registered and legally restricted to the use of the owner or manufacturer.
+    """
+
     LICENCE = "licence"
+    """Formal permission to do something."""
+
     INTELLECTUAL_PROPERTY_RIGHTS = "intellectualPropertyRights"
+    """
+    Rights to financial benefit from and control of distribution of
+    non-tangible property that is a result of creativity.
+    """
+
     RESTRICTED = "restricted"
+    """Withheld from general circulation or disclosure."""
+
     OTHER_RESTRICTIONS = "otherRestrictions"
+    """Limitation not listed."""
+
     UNRESTRICTED = "unrestricted"
+    """No constraints exist."""
+
     LICENCE_UNRESTRICTED = "licenceUnrestricted"
+    """Formal permission not required to use resource."""
+
     LICENCE_END_USER = "licenceEndUser"
+    """
+    Fromal permission required for a person pr an entity to use the resource
+    and that may differ from the person that orders or purchases it.
+    """
+
     LICENCE_DISTRIBUTOR = "licenceDistributor"
+    """
+    Formal permission required for a person or entity to commercialize or
+    distribute the resource.
+    """
+
     PRIVATE = "private"
+    """
+    Protects rights of individual or organisations from observation,
+    intrusion, or attention of others.
+    """
+
     STATUTORY = "statutory"
+    """Prescribed by law."""
+
     CONFIDENTIAL = "confidential"
+    """
+    Not available to the public.
+
+    NOTE: Contains information that could be prejudicial to a commercial,
+    industrial, or national interest.
+    """
+
     SENSITIVE_BUT_UNCLASSIFIED = "sensitiveButUnclassified"
+    """
+    Although unclassified, requires strict controls over its distribution.
+    """
+
     IN_CONFIDENCE = "in-confidence"
+    "With trust."
 
-
-
-from opengis.metadata.citation import Responsibility, Citation
 
 class Releasability(ABC):
-    """State, nation or organization to which resource can be released to e.g. NATO unclassified releasable to PfP."""
+    """
+    State, nation or organisation to which resource can be released,
+    e.g., NATO unclassified releasable to PfP.
+    """
 
     @property
-    def addressee(self) -> Sequence[Responsibility]:
-        """Party responsible for the Release statement."""
-        return None
+    @abstractmethod
+    def addressee(self) -> Optional[Sequence[Responsibility]]:
+        """
+        Party to which the release statement applies.
+
+        MANDATORY: if `statement` is `None`.
+        """
 
     @property
-    def statement(self) -> str:
-        """Release statement."""
-        return None
+    @abstractmethod
+    def statement(self) -> Optional[str]:
+        """
+        Release statement.
+
+        MANDATORY: if `addressee` is `None`.
+        """
 
     @property
-    def dissemination_constraints(self) -> Sequence[RestrictionCode]:
+    @abstractmethod
+    def dissemination_constraints(self) -> Optional[Sequence[RestrictionCode]]:
         """Component in determining releasability."""
-        return None
 
-
-
-from opengis.metadata.maintenance import Scope
 
 class Constraints(ABC):
     """Restrictions on the access and use of a resource or metadata."""
 
     @property
-    def use_limitation(self) -> Sequence[str]:
-        """Limitation affecting the fitness for use of the resource or metadata. Example, "not to be used for navigation"."""
-        return None
+    @abstractmethod
+    def use_limitation(self) -> Optional[Sequence[str]]:
+        """
+        Limitation affecting the fitness for use of the resource or metadata.
+        For example, "not to be used for navigation".
+        """
 
     @property
-    def constraint_application_scope(self) -> Scope:
-        """Spatial and temporal extent of the application of the constraint restrictions."""
-        return None
+    @abstractmethod
+    def constraint_application_scope(self) -> Optional[Scope]:
+        """
+        Spatial and temporal extent of the application of the constraint
+        restrictions.
+        """
 
     @property
-    def graphic(self) -> Sequence['BrowseGraphic']:
+    @abstractmethod
+    def graphic(self) -> Optional[Sequence[BrowseGraphic]]:
         """Graphic /symbol indicating the constraint Eg."""
-        return None
 
     @property
-    def reference(self) -> Sequence[Citation]:
-        """Citation/URL for the limitation or constraint, e.g. copyright statement, license agreement, etc."""
-        return None
+    @abstractmethod
+    def reference(self) -> Optional[Sequence[Citation]]:
+        """
+        Citation/URL for the limitation or constraint,
+        e.g., copyright statement, license agreement, etc.
+        """
 
     @property
-    def releasability(self) -> Releasability:
-        """Information concerning the parties to whom the resource can or cannot be released and the party responsible for determining the releasibility."""
-        return None
+    @abstractmethod
+    def releasability(self) -> Optional[Releasability]:
+        """
+        Information concerning the parties to whom the resource can or cannot
+        be released and the party responsible for determining the
+        releasibility.
+        """
 
     @property
-    def responsible_party(self) -> Sequence[Responsibility]:
+    @abstractmethod
+    def responsible_party(self) -> Optional[Sequence[Responsibility]]:
         """Party responsible for the resource constraints."""
-        return None
-
 
 
 class LegalConstraints(Constraints):
-    """Restrictions and legal prerequisites for accessing and using the resource or metadata."""
+    """
+    Restrictions and legal prerequisites for accessing and using the resource
+    or metadata.
+    """
 
     @property
-    def access_constraints(self) -> Sequence[RestrictionCode]:
-        """Access constraints applied to assure the protection of privacy or intellectual property, and any special restrictions or limitations on obtaining the resource or metadata."""
-        return None
+    @abstractmethod
+    def access_constraints(self) -> Optional[Sequence[RestrictionCode]]:
+        """
+        Access constraints applied to assure the protection of privacy or
+        intellectual property, and any special restrictions or limitations on
+        obtaining the resource or metadata.
+
+        MANDATORY: if `use_constraints`, `other_constrints`, `use_limitations`,
+            or `releasability` are `None`.
+        """
 
     @property
-    def use_constraints(self) -> Sequence[RestrictionCode]:
-        """Constraints applied to assure the protection of privacy or intellectual property, and any special restrictions or limitations or warnings on using the resource or metadata."""
-        return None
+    @abstractmethod
+    def use_constraints(self) -> Optional[Sequence[RestrictionCode]]:
+        """
+        Constraints applied to assure the protection of privacy or
+        intellectual property, and any special restrictions or limitations or
+        warnings on using the resource or metadata.
+
+        MANDATORY: if `access_constraints`, `other_constrints`,
+            `use_limitations`, or `releasability` are `None`.
+        """
 
     @property
-    def other_constraints(self) -> Sequence[str]:
-        """Other restrictions and legal prerequisites for accessing and using the resource or metadata."""
-        return None
+    @abstractmethod
+    def other_constraints(self) -> Optional[Sequence[str]]:
+        """
+        Other restrictions and legal prerequisites for accessing and using the
+        resource or metadata.
 
+        MANDATORY: if `access_constraints`, `use_constrints`,
+            `use_limitations`, or `releasability` are `None`.
+        """
 
 
 class SecurityConstraints(Constraints):
-    """Handling restrictions imposed on the resource or metadata for national security or similar security concerns."""
+    """
+    Handling restrictions imposed on the resource or metadata for national
+    security or similar security concerns.
+    """
 
     @property
     @abstractmethod
     def classification(self) -> ClassificationCode:
         """Name of the handling restrictions on the resource or metadata."""
-        pass
 
     @property
-    def user_note(self) -> str:
-        """Explanation of the application of the legal constraints or other restrictions and legal prerequisites for obtaining and using the resource or metadata."""
-        return None
+    @abstractmethod
+    def user_note(self) -> Optional[str]:
+        """
+        Explanation of the application of the legal constraints or other
+        restrictions and legal prerequisites for obtaining and using the
+        resource or metadata.
+        """
 
     @property
-    def classification_system(self) -> str:
+    @abstractmethod
+    def classification_system(self) -> Optional[str]:
         """Name of the classification system."""
-        return None
 
     @property
-    def handling_description(self) -> str:
-        """Additional information about the restrictions on handling the resource or metadata."""
-        return None
+    @abstractmethod
+    def handling_description(self) -> Optional[str]:
+        """
+        Additional information about the restrictions on handling the resource
+        or metadata.
+        """

--- a/geoapi/src/main/python/opengis/metadata/content.py
+++ b/geoapi/src/main/python/opengis/metadata/content.py
@@ -1,69 +1,234 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the content module.
+
+This module contains geographic metadata structures regarding data content
+derived from the ISO 19115-1:2014 and ISO 19115-2:2019 international standards.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import Citation, Identifier
+from opengis.metadata.naming import GenericName, MemberName, Record, RecordType
+from opengis.util.measure import UnitOfMeasure, UomLength
 
 
 class BandDefinition(Enum):
-    THREE_DB = "3dB"
-    HALF_MAXIMUM = "halfMaximum"
-    FIFTY_PERCENT = "fiftyPercent"
-    ONE_OVER_E = "oneOverE"
-    EQUIVALENT_WIDTH = "equivalentWidth"
+    """
+    Designation of the criterion for defining wavelengths of a spectral band.
+    """
 
+    THREE_DB = "3dB"
+    """
+    Width of a distribution equal to the distance between the outer two points\
+    on the distribution having power level half of that at the peak.
+    """
+
+    HALF_MAXIMUM = "halfMaximum"
+    """
+    Width of a distribution equal to the distance between the outer two points
+    on the distribution having power level half of that at the peak.
+    """
+
+    FIFTY_PERCENT = "fiftyPercent"
+    """
+    Full spectral width of a spectral power density measured at 50 % of its
+    peak height.
+    """
+
+    ONE_OVER_E = "oneOverE"
+    """
+    Width of a distribution equal to the distance between the outer two points
+    on the distribution having power level 1/e that of the peak.
+    """
+
+    EQUIVALENT_WIDTH = "equivalentWidth"
+    """
+    Width of a band with full sensitivity or absorption at every wavelength
+    that detects or absorbs the same amount of energy as the band described.
+    """
 
 
 class CoverageContentTypeCode(Enum):
-    IMAGE = "image"
-    THEMATIC_CLASSIFICATION = "thematicClassification"
-    PHYSICAL_MEASUREMENT = "physicalMeasurement"
-    AUXILLARY_INFORMATION = "auxillaryInformation"
-    QUALITY_INFORMATION = "qualityInformation"
-    REFERENCE_INFORMATION = "referenceInformation"
-    MODEL_RESULT = "modelResult"
-    COORDINATE = "coordinate"
+    """
+    Transformation function to be used when scaling a physical value of a
+    given element.
+    """
 
+    IMAGE = "image"
+    """
+    Meaningful numerical representation of a physical parameter that is not
+    the actual value of the physical parameter.
+    """
+
+    THEMATIC_CLASSIFICATION = "thematicClassification"
+    """
+    Code value with no quantitative meaning, used to represent a
+    physical quantity.
+    """
+
+    PHYSICAL_MEASUREMENT = "physicalMeasurement"
+    """Value in physical units of the quantity being measured."""
+
+    AUXILLARY_INFORMATION = "auxillaryInformation"
+    """
+    Data, usually a physical measurement, used to support the calculation
+    of the primary PHYSICAL_MEASUREMENT coverages in the dataset.
+
+    EXAMPLE: Grid of aerosol optical thickness used in the calculation of a
+    sea surface temperature product.
+    """
+
+    QUALITY_INFORMATION = "qualityInformation"
+    """
+    Data used to characterize the quality of the PHYSICAL_MEASUREMENT coverages
+    in the dataset.
+
+    NOTE: Typically included in a gmi:QE_CoverageResult.
+    """
+
+    REFERENCE_INFORMATION = "referenceInformation"
+    """
+    Reference information used to support the calculation or use of the
+    PHYSICAL_MEASUREMENT coverages in the dataset.
+
+    EXAMPLE: Grids of latitude/longitude used to geolocate
+    the physical measurements.
+    """
+
+    MODEL_RESULT = "modelResult"
+    """
+    Resources with values that are calculated using a model rather than being
+    observed or calculated from observations.
+    """
+
+    COORDINATE = "coordinate"
+    """Data used to provide coordinate axis values."""
 
 
 class ImagingConditionCode(Enum):
-    BLURRED_IMAGE = "blurredImage"
-    CLOUD = "cloud"
-    DEGRADING_OBLIQUITY = "degradingObliquity"
-    FOG = "fog"
-    HEAVY_SMOKE_OR_DUST = "heavySmokeOrDust"
-    NIGHT = "night"
-    RAIN = "rain"
-    SEMI_DARKNESS = "semiDarkness"
-    SHADOW = "shadow"
-    SNOW = "snow"
-    TERRAIN_MASKING = "terrainMasking"
+    """
+    Code which indicates conditions which may affect the image.
+    """
 
+    BLURRED_IMAGE = "blurredImage"
+    """Portion of the image is blurred."""
+
+    CLOUD = "cloud"
+    """Portion of the image is partially obscured by cloud cover."""
+
+    DEGRADING_OBLIQUITY = "degradingObliquity"
+    """
+    Acute angle between the plane of the ecliptic (the plane of the Earth's
+    orbit) and the plane of the celestial equator.
+    """
+
+    FOG = "fog"
+    """Portion of the image is partially obscured by fog."""
+
+    HEAVY_SMOKE_OR_DUST = "heavySmokeOrDust"
+    """Portion of the image is partially obscured by heavy smoke or dust."""
+
+    NIGHT = "night"
+    """Image was taken at night."""
+
+    RAIN = "rain"
+    """Image was taken during rainfall."""
+
+    SEMI_DARKNESS = "semiDarkness"
+    """
+    Image was taken during semi-dark conditions - twilight conditions.
+    """
+    SHADOW = "shadow"
+    """Portion of the image is obscured by shadow."""
+
+    SNOW = "snow"
+    """Portion of the image is obscured by snow."""
+
+    TERRAIN_MASKING = "terrainMasking"
+    """
+    The absence of collection data of a given point or area caused by the
+    relative location of topographic features which obstruct the collection
+    path between the collector(s) and the subject(s) of interes.
+    """
 
 
 class PolarisationOrientationCode(Enum):
-    HORIZONTAL = "horizontal"
-    VERTICAL = "vertical"
-    LEFT_CIRCULAR = "leftCircular"
-    RIGHT_CIRCULAR = "rightCircular"
-    THETA = "theta"
-    PHI = "phi"
+    """Polarization of the antenna in relation to the wave form."""
 
+    HORIZONTAL = "horizontal"
+    """
+    Polarization of the sensor oriented in the horizontal plane in relation to
+    swathe direction.
+    """
+
+    VERTICAL = "vertical"
+    """
+    Polarization of the sensor oriented in the vertical plane in relation to
+    swathe direction.
+    """
+
+    LEFT_CIRCULAR = "leftCircular"
+    """
+    Polarization of the sensor oriented in the left circular plane in relation
+    to swathe direction.
+    """
+
+    RIGHT_CIRCULAR = "rightCircular"
+    """
+    Polarization of the sensor oriented in the right circular plane in relation
+    to swathe direction.
+    """
+
+    THETA = "theta"
+    """
+    Polarization of the sensor oriented in the angle between +90° and 0°
+    parallel to swathe direction.
+    """
+
+    PHI = "phi"
+    """
+    Polarization of the sensor oriented in the +90° and 0° perpendicular to
+    swathe direction.
+    """
 
 
 class TransferFunctionTypeCode(Enum):
+    """
+    Transform function to be used when scaling a physical value for a given
+    element.
+    """
+
     LINEAR = "linear"
+    """Function used when transformation is first order polynomial."""
+
     LOGARITHMIC = "logarithmic"
+    """Function used when transformation is logartihmic."""
+
     EXPONENTIAL = "exponential"
+    """Function used when transformation is exponential."""
 
-
-
-from opengis.metadata.naming import Record, MemberName, RecordType, GenericName
 
 class RangeElementDescription(ABC):
     """Description of specific range elements."""
@@ -72,178 +237,245 @@ class RangeElementDescription(ABC):
     @abstractmethod
     def name(self) -> str:
         """Designation associated with a set of range elements."""
-        pass
 
     @property
     @abstractmethod
     def definition(self) -> str:
         """Description of a set of specific range elements."""
-        pass
 
     @property
     @abstractmethod
     def range_element(self) -> Sequence[Record]:
-        """Specific range elements, i.e. range elements associated with a name and definition defining their meaning."""
-        pass
+        """
+        Specific range elements, i.e. range elements associated with a name
+        and their definition.
+        """
 
-
-
-from opengis.metadata.citation import Identifier, Citation
 
 class RangeDimension(ABC):
     """Information on the range of attribute values."""
 
     @property
-    def sequence_identifier(self) -> MemberName:
-        """Number that uniquely identifies instances of bands of wavelengths on which a sensor operates."""
-        return None
+    @abstractmethod
+    def sequence_identifier(self) -> Optional[MemberName]:
+        """
+        Number that uniquely identifies instances of bands of wavelengths on
+        which a sensor operates.
+        """
 
     @property
-    def description(self) -> str:
+    @abstractmethod
+    def description(self) -> Optional[str]:
         """Description of the range of a cell measurement value."""
-        return None
 
     @property
-    def name(self) -> Sequence[Identifier]:
-        """Identifiers for each attribute included in the resource. These identifiers can be used to provide names for the resource's attribute from a standard set of names."""
-        return None
+    @abstractmethod
+    def name(self) -> Optional[Sequence[Identifier]]:
+        """
+        Identifiers for each attribute included in the resource.
 
+        NOTE: These identifiers can be used to provide names for the
+        resource's attribute from a standard set of names.
+        """
 
 
 class AttributeGroup(ABC):
+    """
+    Information about the `content_type` for groups of attributes for a
+    specific `RangeDimension`.
+    """
 
     @property
     @abstractmethod
     def content_type(self) -> Sequence[CoverageContentTypeCode]:
         """Type of information represented by the value."""
-        pass
 
     @property
-    def attribute(self) -> Sequence[RangeDimension]:
-        return None
-
+    @abstractmethod
+    def attribute(self) -> Optional[Sequence[RangeDimension]]:
+        """Information on an attribute of the resource."""
 
 
 class SampleDimension(RangeDimension):
-    """The characteristics of each dimension (layer) included in the resource."""
+    """
+    The characteristics of each dimension (layer) included in the resource.
+    """
 
     @property
-    def max_value(self) -> float:
-        """Maximum value of data values in each dimension included in the resource. Restricted to UomLength in the MD_Band class."""
-        return None
+    @abstractmethod
+    def max_value(self) -> Optional[float]:
+        """
+        Maximum value of data values in each dimension included in the
+        resource.
+
+        NOTE: Restricted to UomLength in the `Band` class.
+        """
 
     @property
-    def min_value(self) -> float:
-        """Minimum value of data values in each dimension included in the resource. Restricted to UomLength in the MD_Band class."""
-        return None
+    @abstractmethod
+    def min_value(self) -> Optional[float]:
+        """
+        Minimum value of data values in each dimension included in the
+        resource.
+
+        Restricted to `UomLength` in the `Band` class.
+        """
 
     @property
-    def units(self):
-        """Units of data in each dimension included in the resource. Note that the type of this is UnitOfMeasure and that it is restricted to UomLength in the MD_Band class."""
-        return None
+    @abstractmethod
+    def units(self) -> Optional[UnitOfMeasure]:
+        """
+        Units of data in each dimension included in the resource.
+
+        NOTE: that the type of this is `UnitOfMeasure` and that it is
+        restricted further for the `Band` class to being of type `UomLength`.
+
+        MANDATORY if `max_value` or `min_value` is specified.
+        """
 
     @property
-    def scale_factor(self) -> float:
+    @abstractmethod
+    def scale_factor(self) -> Optional[float]:
         """Scale factor which has been applied to the cell value."""
-        return None
 
     @property
-    def offset(self) -> float:
+    @abstractmethod
+    def offset(self) -> Optional[float]:
         """The physical value corresponding to a cell value of zero."""
-        return None
 
     @property
-    def mean_value(self) -> float:
-        """Mean value of data values in each dimension included in the resource."""
-        return None
+    @abstractmethod
+    def mean_value(self) -> Optional[float]:
+        """
+        Mean value of data values in each dimension included in the resource.
+        """
 
     @property
-    def number_of_values(self) -> int:
-        """This gives the number of values used in a thematicClassification resource EX:. the number of classes in a Land Cover Type coverage or the number of cells with data in other types of coverages."""
-        return None
+    @abstractmethod
+    def number_of_values(self) -> Optional[int]:
+        """
+        This gives the number of values used in a thematicClassification
+        resource, e.g., the number of classes in a Land Cover Type coverage or
+        the number of cells with data in other types of coverages.
+        """
 
     @property
-    def standard_deviation(self) -> float:
-        """Standard deviation of data values in each dimension included in the resource."""
-        return None
+    @abstractmethod
+    def standard_deviation(self) -> Optional[float]:
+        """
+        Standard deviation of data values in each dimension included in the
+        resource.
+        """
 
     @property
-    def other_property_type(self) -> RecordType:
-        """Type of other attribute description (i.e. netcdf/variable in ncml.xsd)."""
-        return None
+    @abstractmethod
+    def other_property_type(self) -> Optional[RecordType]:
+        """
+        Type of other attribute description (i.e. netcdf/variable in ncml.xsd).
+        """
 
     @property
-    def other_property(self) -> Record:
-        """Instance of otherAttributeType that defines attributes not explicitly included in MD_CoverageType."""
-        return None
+    @abstractmethod
+    def other_property(self) -> Optional[Record]:
+        """
+        Instance of otherAttributeType that defines attributes not explicitly
+        included in `CoverageType`.
+        """
 
     @property
-    def bits_per_value(self) -> int:
-        """Maximum number of significant bits in the uncompressed representation for the value in each band of each pixel."""
-        return None
+    @abstractmethod
+    def bits_per_value(self) -> Optional[int]:
+        """
+        Maximum number of significant bits in the uncompressed representation
+        for the value in each band of each pixel.
+        """
 
     @property
-    def transfer_function_type(self) -> TransferFunctionTypeCode:
-        """Type of transfer function to be used when scaling a physical value for a given element."""
-        return None
+    @abstractmethod
+    def transfer_function_type(self) -> Optional[TransferFunctionTypeCode]:
+        """
+        Type of transfer function to be used when scaling a physical value for
+        a given element.
+        """
 
     @property
+    @abstractmethod
     def range_element_description(self) -> Sequence[RangeElementDescription]:
-        """Provides the description and values of the specific range elements of a sample dimension."""
-        return None
+        """
+        Provides the description and values of the specific range elements of
+        a sample dimension.
+        """
 
     @property
-    def nominal_spatial_resolution(self) -> float:
-        """Smallest distance between which separate points can be distinguished, as specified in instrument design."""
-        return None
-
+    @abstractmethod
+    def nominal_spatial_resolution(self) -> Optional[float]:
+        """
+        Smallest distance between which separate points can be distinguished,
+        as specified in instrument design.
+        """
 
 
 class Band(SampleDimension):
     """Range of wavelengths in the electromagnetic spectrum."""
 
     @property
-    def bound_max(self) -> float:
-        return None
+    @abstractmethod
+    def bound_max(self) -> Optional[float]:
+        """
+        Bounding maximum. The longest wavelength that the sensor is capable of
+        collecting within a designated band.
+        """
 
     @property
-    def bound_min(self) -> float:
-        return None
+    @abstractmethod
+    def bound_min(self) -> Optional[float]:
+        """
+        Bounding minimum. The shortest wavelength that the sensor is capable of
+        collecting within a designated band.
+        """
 
     @property
-    def bound_units(self):
-        return None
+    @abstractmethod
+    def bound_unit(self) -> Optional[UomLength]:
+        """
+        Bounding units. The units in which the sensor wavelengths are
+        expressed.
+
+        MANDATORY if `bound_max` or `bound_min` is specified.
+        """
 
     @property
-    def peak_response(self) -> float:
+    @abstractmethod
+    def peak_response(self) -> Optional[float]:
         """Wavelength at which the response is the highest."""
-        return None
 
     @property
-    def tone_gradation(self) -> int:
-        """Number of discrete numerical values in the grid data."""
-        return None
+    @abstractmethod
+    def tone_gradation(self) -> Optional[int]:
+        """Number of discrete numerical values in the data."""
 
     @property
-    def band_boundary_definition(self) -> BandDefinition:
-        """Designation of criterion for defining maximum and minimum wavelengths for a spectral band."""
-        return None
+    @abstractmethod
+    def band_boundary_definition(self) -> Optional[BandDefinition]:
+        """
+        Designation of criterion for defining maximum and minimum wavelengths
+        for a spectral band.
+        """
 
     @property
-    def transmitted_polarisation(self) -> PolarisationOrientationCode:
+    @abstractmethod
+    def transmitted_polarisation(self) -> \
+            Optional[PolarisationOrientationCode]:
         """Polarisation of the transmitter or detector."""
-        return None
 
     @property
-    def detected_polarisation(self) -> PolarisationOrientationCode:
+    @abstractmethod
+    def detected_polarisation(self) -> Optional[PolarisationOrientationCode]:
         """Polarisation of the transmitter or detector."""
-        return None
-
 
 
 class ContentInformation(ABC):
     """Description of the content of a resource."""
-
 
 
 class CoverageDescription(ContentInformation):
@@ -253,120 +485,210 @@ class CoverageDescription(ContentInformation):
     @abstractmethod
     def attribute_description(self) -> RecordType:
         """Description of the attribute described by the measurement value."""
-        pass
 
     @property
-    def processing_level_code(self) -> Identifier:
-        """Code and codespace that identifies the level of processing that has been applied to the resource."""
-        return None
+    @abstractmethod
+    def processing_level_code(self) -> Optional[Identifier]:
+        """
+        Code and codespace that identifies the level of processing that has
+        been applied to the resource.
+        """
 
     @property
-    def attribute_group(self) -> Sequence[AttributeGroup]:
-        return None
+    @abstractmethod
+    def attribute_group(self) -> Optional[Sequence[AttributeGroup]]:
+        """
+        Information on the group(s) of related attributes of the resource
+        with the same type.
+        """
 
     @property
-    def range_element_description(self) -> Sequence[RangeElementDescription]:
-        return None
-
+    @abstractmethod
+    def range_element_description(self) -> Optional[Sequence[
+        RangeElementDescription
+    ]]:
+        """
+        Provides the description of the specific range elements of a coverage.
+        """
 
 
 class ImageDescription(CoverageDescription):
     """Information about an image's suitability for use."""
 
     @property
-    def illumination_elevation_angle(self) -> float:
-        """Illumination elevation measured in degrees clockwise from the target plane at intersection of the optical line of sight with the Earth's surface. For images from a scanning device, refer to the centre pixel of the image."""
-        return None
+    @abstractmethod
+    def illumination_elevation_angle(self) -> Optional[float]:
+        """
+        Illumination elevation measured in degrees clockwise from the target
+        plane at intersection of the optical line of sight with the Earth's
+        surface.
+
+        NOTE: For images from a scanning device, refer to the centre pixel
+        of the image.
+
+        Domain: -90 - 90
+        """
 
     @property
-    def illumination_azimuth_angle(self) -> float:
-        """Illumination azimuth measured in degrees clockwise from true north at the time the image is taken. For images from a scanning device, refer to the centre pixel of the image."""
-        return None
+    @abstractmethod
+    def illumination_azimuth_angle(self) -> Optional[float]:
+        """
+        Illumination azimuth measured in degrees clockwise from true north at
+        the time the image is taken.
+
+        NOTE: For images from a scanning device, refer to the centre pixel of
+        the image.
+
+        Domain: 0.00 - 360
+        """
 
     @property
-    def imaging_condition(self) -> ImagingConditionCode:
-        """Conditions affected the image."""
-        return None
+    @abstractmethod
+    def imaging_condition(self) -> Optional[ImagingConditionCode]:
+        """Conditions that affected the image."""
 
     @property
-    def image_quality_code(self) -> Identifier:
-        """Code in producers code space that specifies the image quality."""
-        return None
+    @abstractmethod
+    def image_quality_code(self) -> Optional[Identifier]:
+        """Code in producer's code space that specifies the image quality."""
 
     @property
-    def cloud_cover_percentage(self) -> float:
-        """Area of the dataset obscured by clouds, expressed as a percentage of the spatial extent."""
-        return None
+    @abstractmethod
+    def cloud_cover_percentage(self) -> Optional[float]:
+        """
+        Area of the dataset obscured by clouds, expressed as a percentage of
+        the spatial extent.
+
+        Domain: 0.0 - 100.0
+        """
 
     @property
-    def compression_generation_quantity(self) -> int:
-        """Count of the number of lossy compression cycles performed on the image."""
-        return None
+    @abstractmethod
+    def compression_generation_quantity(self) -> Optional[int]:
+        """
+        Count of the number of lossy compression cycles performed on the image.
+        """
 
     @property
-    def triangulation_indicator(self):
-        """Indication of whether or not triangulation has been performed upon the image."""
-        return None
+    @abstractmethod
+    def triangulation_indicator(self) -> Optional[bool]:
+        """
+        Indication of whether or not triangulation has been performed upon the
+        image.
+        """
 
     @property
-    def radiometric_calibration_data_availability(self):
-        """Indication of whether or not the radiometric calibration information for generating the radiometrically calibrated standard data product is available."""
-        return None
+    @abstractmethod
+    def radiometric_calibration_data_availability(self) -> Optional[bool]:
+        """
+        Indication of whether or not the radiometric calibration information
+        for generating the radiometrically calibrated standard data product is
+        available.
+        """
 
     @property
-    def camera_calibration_information_availability(self):
-        """Indication of whether or not constants are available which allow for camera calibration corrections."""
-        return None
+    @abstractmethod
+    def camera_calibration_information_availability(self) -> Optional[bool]:
+        """
+        Indication of whether or not constants are available which allow for
+        camera calibration corrections.
+        """
 
     @property
-    def film_distortion_information_availability(self):
-        """Indication of whether or not Calibration Reseau information is available."""
-        return None
+    @abstractmethod
+    def film_distortion_information_availability(self) -> Optional[bool]:
+        """
+        Indication of whether or not Calibration Reseau information is
+        available.
+        """
 
     @property
-    def lens_distortion_information_availability(self):
-        """Indication of whether or not lens aberration correction information is available."""
-        return None
-
+    @abstractmethod
+    def lens_distortion_information_availability(self) -> Optional[bool]:
+        """
+        Indication of whether or not lens aberration correction information is
+        available.
+        """
 
 
 class FeatureTypeInfo(ABC):
+    """Information about the occurring feature type."""
 
     @property
     @abstractmethod
     def feature_type_name(self) -> GenericName:
-        pass
+        """Name of the feature type."""
 
     @property
-    def feature_instance_count(self) -> int:
-        return None
+    @abstractmethod
+    def feature_instance_count(self) -> Optional[int]:
+        """
+        Number of occurences of feature instances for this type.
 
+        Domain: > 0
+        """
 
 
 class FeatureCatalogueDescription(ContentInformation):
-    """Information identifying the feature catalogue or the conceptual schema."""
+    """
+    Information identifying the feature catalogue or the conceptual schema.
+    """
 
     @property
-    def compliance_code(self):
-        """Indication of whether or not the cited feature catalogue complies with ISO 19110."""
-        return None
+    @abstractmethod
+    def compliance_code(self) -> Optional[bool]:
+        """
+        Indication of whether or not the cited feature catalogue complies with
+        ISO 19110.
+        """
 
     @property
-    def locale(self):
-        """Language(s) used within the catalogue."""
-        return None
+    @abstractmethod
+    def locale(self) -> Optional[Sequence[str]]:
+        """
+        Language(s) and character set(s) used within the catalogue. A string
+        conforming to IETF BCP 47.
+        """
 
     @property
-    def included_with_dataset(self):
-        """Indication of whether or not the feature catalogue is included with the resource."""
-        return None
+    @abstractmethod
+    def included_with_dataset(self) -> Optional[bool]:
+        """
+        Indication of whether or not the feature catalogue is included with
+        the resource.
+        """
 
     @property
-    def feature_types(self) -> Sequence[FeatureTypeInfo]:
-        """Subset of feature types from cited feature catalogue occurring in dataset."""
-        return None
+    @abstractmethod
+    def feature_types(self) -> Optional[Sequence[FeatureTypeInfo]]:
+        """
+        Subset of feature types from cited feature catalogue occurring in
+        dataset.
+        """
 
     @property
-    def feature_catalogue_citation(self) -> Sequence[Citation]:
-        """Complete bibliographic reference to one or more external feature catalogues."""
-        return None
+    @abstractmethod
+    def feature_catalogue_citation(self) -> Optional[Sequence[Citation]]:
+        """
+        Complete bibliographic reference to one or more external feature
+        catalogues.
+
+        MANADTORY: if a Feature Catalogue is not provided with the resource
+            and `FeatureCatalogue` is `None`.
+        """
+
+
+# ISO 19115:2014 MD_FeatureCatalogue
+# Need to implement ISO 19110 FC_FeatureCatalogue and related objects
+# class FeatureCatalogue(ContentInformation):
+#     """A catalogue of feature types."""
+
+#     @property
+#     @abstractmethod
+#     def feature_catalogue(self) -> Optional[Sequence[FC_FeatureCatalogue]]:
+#         """
+#         The catalogue of feature types, attribution, operations, and
+#         relationships used by the resource.
+
+#         Derived from FC_FeatureCatalogue from ISO 19110.
+#         """

--- a/geoapi/src/main/python/opengis/metadata/distribution.py
+++ b/geoapi/src/main/python/opengis/metadata/distribution.py
@@ -1,98 +1,153 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the distribution module.
+
+This module contains geographic metadata structures regarding data
+distribution derived from the ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import datetime, timedelta
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import (
+    Citation,
+    Identifier,
+    OnlineResource,
+    Responsibility,
+)
+from opengis.metadata.naming import GenericName, Record, RecordType
 
 
 class MediumFormatCode(Enum):
+    """Method used to write to the medium."""
+
     CPIO = "cpio"
+    """Copy In / Out (UNIX file format and command)."""
+
     TAR = "tar"
+    """Tape Archive."""
+
     HIGH_SIERRA = "highSierra"
+    """High sierra file system."""
+
     ISO_9660 = "iso9660"
+    """Information processing - volume and file structure of CD-ROM."""
+
     ISO_9660_ROCK_RIDGE = "iso9660RockRidge"
+    """Rock ridge interchange protocol (UNIX)."""
+
     ISO_9660_APPLE_HFS = "iso9660AppleHFS"
+    """Hierarchical file system (Macintosh)."""
+
     UDF = "udf"
+    """Universal disk format."""
 
-
-
-from opengis.metadata.citation import Citation, Identifier, OnlineResource, Responsibility
 
 class Medium(ABC):
     """Information about the media on which the resource can be distributed."""
 
     @property
-    def name(self) -> Citation:
+    @abstractmethod
+    def name(self) -> Optional[Citation]:
         """Name of the medium on which the resource can be received."""
-        return None
 
     @property
-    def density(self) -> float:
-        """Density at which the data is recorded."""
-        return None
+    @abstractmethod
+    def density(self) -> Optional[float]:
+        """
+        Density at which the data is recorded.
+
+        Domain: > 0.0
+        """
 
     @property
-    def density_units(self):
+    @abstractmethod
+    def density_units(self) -> Optional[str]:
         """Units of measure for the recording density."""
-        return None
 
     @property
-    def volumes(self) -> int:
-        """Number of items in the media identified."""
-        return None
+    @abstractmethod
+    def volumes(self) -> Optional[int]:
+        """
+        Number of items in the media identified.
+
+        Domain: > 0
+        """
 
     @property
-    def medium_format(self) -> Sequence[MediumFormatCode]:
+    @abstractmethod
+    def medium_format(self) -> Optional[Sequence[MediumFormatCode]]:
         """Method used to write to the medium."""
-        return None
 
     @property
-    def medium_note(self) -> str:
-        """Description of other limitations or requirements for using the medium."""
-        return None
+    @abstractmethod
+    def medium_note(self) -> Optional[str]:
+        """
+        Description of other limitations or requirements for using the medium.
+        """
 
     @property
-    def identifier(self) -> Identifier:
-        return None
-
+    @abstractmethod
+    def identifier(self) -> Optional[Identifier]:
+        """Unique identifier for an instance of the `Medium`."""
 
 
 class Format(ABC):
-    """Description of the computer language construct that specifies the representation of data objects in a record, file, message, storage device or transmission channel."""
+    """
+    Description of the computer language construct that specifies the
+    representation of data objects in a record, file, message, storage device
+    or transmission channel.
+    """
 
     @property
     @abstractmethod
     def format_specification_citation(self) -> Citation:
         """Citation/URL of the specification for the format."""
-        pass
 
     @property
-    def amendment_number(self) -> str:
+    @abstractmethod
+    def amendment_number(self) -> Optional[str]:
         """Amendment number of the format version."""
-        return None
 
     @property
-    def file_decompression_technique(self) -> str:
-        """Recommendations of algorithms or processes that can be applied to read or expand resources to which compression techniques have been applied."""
-        return None
+    @abstractmethod
+    def file_decompression_technique(self) -> Optional[str]:
+        """
+        Recommendations of algorithms or processes that can be applied to read
+        or expand resources to which compression techniques have been applied.
+        """
 
     @property
-    def medium(self) -> Sequence[Medium]:
+    @abstractmethod
+    def medium(self) -> Optional[Sequence[Medium]]:
         """Medium used by the format."""
-        return None
 
     @property
-    def format_distributor(self) -> Sequence['Distributor']:
-        return None
+    @abstractmethod
+    def format_distributor(self) -> Optional[Sequence['Distributor']]:
+        """Provides information about the distributor of the format."""
 
-
-
-from opengis.metadata.naming import GenericName, RecordType, Record
 
 class DataFile(ABC):
     """Description of a transfer data file."""
@@ -101,97 +156,65 @@ class DataFile(ABC):
     @abstractmethod
     def file_name(self):
         """Name of the file that contains the data."""
-        pass
 
     @property
     @abstractmethod
     def file_description(self) -> str:
         """Text description of the data."""
-        pass
 
     @property
     @abstractmethod
     def file_type(self) -> str:
         """Format in which the data is encoded."""
-        pass
 
     @property
+    @abstractmethod
     def feature_types(self) -> Sequence[GenericName]:
-        """Provides the list of feature types concerned by the transfer data file."""
-        return None
+        """
+        Provides the list of feature types concerned by the transfer data file.
+        """
 
-
-
-class DigitalTransferOptions(ABC):
-    """Technical means and media by which a resource is obtained from the distributor."""
-
-    @property
-    def units_of_distribution(self) -> str:
-        """Tiles, layers, geographic areas, etc., in which data is available. NOTE: unitsOfDistribution applies to both onLine and offLine distributions."""
-        return None
-
-    @property
-    def transfer_size(self) -> float:
-        """Estimated size of a unit in the specified transfer format, expressed in megabytes. The transfer size is > 0.0."""
-        return None
-
-    @property
-    def on_line(self) -> Sequence[OnlineResource]:
-        """Information about online sources from which the resource can be obtained."""
-        return None
-
-    @property
-    def off_line(self) -> Sequence[Medium]:
-        """Information about offline media on which the resource can be obtained."""
-        return None
-
-    @property
-    def transfer_frequency(self):
-        """Rate of occurrence of distribution."""
-        return None
-
-    @property
-    def distribution_format(self) -> Sequence[Format]:
-        """Format of distribution."""
-        return None
-
-
-
-from datetime import datetime
 
 class StandardOrderProcess(ABC):
-    """Common ways in which the resource may be obtained or received, and related instructions and fee information."""
+    """
+    Common ways in which the resource may be obtained or received, and related
+    instructions and fee information.
+    """
 
     @property
-    def fees(self) -> str:
-        """Fees and terms for retrieving the resource. Include monetary units (as specified in ISO 4217)."""
-        return None
+    @abstractmethod
+    def fees(self) -> Optional[str]:
+        """
+        Fees and terms for retrieving the resource. Include monetary units
+        (as specified in ISO 4217).
+        """
 
     @property
-    def planned_available_date_time(self) -> datetime:
+    @abstractmethod
+    def planned_available_date_time(self) -> Optional[datetime]:
         """Date and time when the resource will be available."""
-        return None
 
     @property
-    def ordering_instructions(self) -> str:
-        """General instructions, terms and services provided by the distributor."""
-        return None
+    @abstractmethod
+    def ordering_instructions(self) -> Optional[str]:
+        """
+        General instructions, terms and services provided by the distributor.
+        """
 
     @property
-    def turnaround(self) -> str:
+    @abstractmethod
+    def turnaround(self) -> Optional[str]:
         """Typical turnaround time for the filling of an order."""
-        return None
 
     @property
-    def order_options_type(self) -> RecordType:
+    @abstractmethod
+    def order_options_type(self) -> Optional[RecordType]:
         """Description of the order options record."""
-        return None
 
     @property
-    def order_options(self) -> Record:
+    @abstractmethod
+    def order_options(self) -> Optional[Record]:
         """Request/purchase choices."""
-        return None
-
 
 
 class Distributor(ABC):
@@ -200,38 +223,118 @@ class Distributor(ABC):
     @property
     @abstractmethod
     def distributor_contact(self) -> Responsibility:
-        """Party from whom the resource may be obtained. This list need not be exhaustive."""
-        pass
+        """
+        Party from whom the resource may be obtained. This list need not be
+        exhaustive.
+        """
 
     @property
-    def distribution_order_process(self) -> Sequence[StandardOrderProcess]:
-        return None
+    @abstractmethod
+    def distribution_order_process(self) -> Optional[Sequence[
+        StandardOrderProcess
+    ]]:
+        """
+        Provides information abouthowthe resource may be obtained and related
+        instructions and fee information.
+        """
 
     @property
-    def distributor_format(self) -> Sequence[Format]:
-        return None
+    @abstractmethod
+    def distributor_format(self) -> Optional[Sequence[Format]]:
+        """Provides information about the format used by the distributor."""
 
     @property
-    def distributor_transfer_options(self) -> Sequence[DigitalTransferOptions]:
-        return None
-
+    @abstractmethod
+    def distributor_transfer_options(self) -> Optional[Sequence[
+        'DigitalTransferOptions'
+    ]]:
+        """
+        Provides information about the technical means and media used by
+        the distributor.
+        """
 
 
 class Distribution(ABC):
-    """Information about the distributor of and options for obtaining the resource."""
+    """
+    Information about the distributor of and options for obtaining the
+    resource.
+    """
 
     @property
-    def description(self) -> str:
-        return None
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """Brief description of a set of distribution options."""
 
     @property
-    def distribution_format(self) -> Sequence[Format]:
-        return None
+    @abstractmethod
+    def distribution_format(self) -> Optional[Sequence[Format]]:
+        """
+        Provides the description of the format of the data to be distributed.
+        """
 
     @property
-    def distributor(self) -> Sequence[Distributor]:
-        return None
+    @abstractmethod
+    def distributor(self) -> Optional[Sequence[Distributor]]:
+        """Provides information about the distributor."""
 
     @property
-    def transfer_options(self) -> Sequence[DigitalTransferOptions]:
-        return None
+    @abstractmethod
+    def transfer_options(self) -> Optional[Sequence['DigitalTransferOptions']]:
+        """
+        Provides information about technical means and media by which a
+        resource is obtained from the distributor.
+        """
+
+
+class DigitalTransferOptions(ABC):
+    """
+    Technical means and media by which a resource is obtained from the
+    distributor.
+    """
+
+    @property
+    @abstractmethod
+    def units_of_distribution(self) -> Optional[str]:
+        """
+        Tiles, layers, geographic areas, etc., in which data is available.
+
+        NOTE: units_of_distribution applies to both onLine and offLine
+        distributions.
+        """
+
+    @property
+    @abstractmethod
+    def transfer_size(self) -> Optional[float]:
+        """
+        Estimated size of a unit in the specified transfer format, expressed
+        in megabytes.
+
+        NOTE: The transfer size is > 0.0.
+
+        Domain: > 0.0
+        """
+
+    @property
+    @abstractmethod
+    def on_line(self) -> Optional[Sequence[OnlineResource]]:
+        """
+        Information about online sources from which the resource can be
+        obtained.
+        """
+
+    @property
+    @abstractmethod
+    def off_line(self) -> Optional[Sequence[Medium]]:
+        """
+        Information about offline media on which the resource can be obtained.
+        """
+
+    @property
+    @abstractmethod
+    def transfer_frequency(self) -> Optional[timedelta]:
+        """Rate of occurrence of distribution."""
+
+    @property
+    @abstractmethod
+    def distribution_format(self) -> Optional[Sequence[Format]]:
+        """Format of distribution."""

--- a/geoapi/src/main/python/opengis/metadata/extension.py
+++ b/geoapi/src/main/python/opengis/metadata/extension.py
@@ -1,43 +1,131 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the extension module.
+
+This module contains geographic metadata structures for metadata elements that
+are not contained in the ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import Citation, OnlineResource, Responsibility
 
 
 class DatatypeCode(Enum):
-    CLASS = "class"
-    CODE_LIST = "codelist"
-    ENUMERATION = "enumeration"
-    CODE_LIST_ELEMENT = "codelistElement"
-    ABSTRACT_CLASS = "abstractClass"
-    AGGREGATE_CLASS = "aggregateClass"
-    SPECIFIED_CLASS = "specifiedClass"
-    DATATYPE_CLASS = "datatypeClass"
-    INTERFACE_CLASS = "interfaceClass"
-    UNION_CLASS = "unionClass"
-    META_CLASS = "metaClass"
-    TYPE_CLASS = "typeClass"
-    CHARACTER_STRING = "characterString"
-    INTEGER = "integer"
-    ASSOCIATION = "association"
+    """Datatype of element or entity."""
 
+    CLASS = "class"
+    """
+    Descriptor of a set of objects that share the same attributes, operations,
+    methods, relationships, and behaviour.
+    """
+
+    CODE_LIST = "codelist"
+    """
+    Flexible enumeration useful for expressing a long list of values, can be
+    extended.
+    """
+
+    ENUMERATION = "enumeration"
+    """
+    Data type whose instances form a list of named literal values, not
+    extendable.
+    """
+
+    CODE_LIST_ELEMENT = "codelistElement"
+    """Permissible value for a codelist or enumeration."""
+
+    ABSTRACT_CLASS = "abstractClass"
+    """Class that cannot be directly instantiated"""
+
+    AGGREGATE_CLASS = "aggregateClass"
+    """
+    Class that is composed of classes it is connected to by an aggregate
+    relationship.
+    """
+
+    SPECIFIED_CLASS = "specifiedClass"
+    """Subclass that may be substituted for its superclass."""
+
+    DATATYPE_CLASS = "datatypeClass"
+    """
+    Class  with few or no operations whose primary purpose is to hold the
+    abstract state of another class for transmittal, storage, encoding, or
+    persistent storage.
+    """
+
+    INTERFACE_CLASS = "interfaceClass"
+    """
+    Named set of operations that characterize the bahaviour of an element.
+    """
+
+    UNION_CLASS = "unionClass"
+    """Class describing a selection of one of the specified types."""
+
+    META_CLASS = "metaClass"
+    """Class whose instances are classes."""
+
+    TYPE_CLASS = "typeClass"
+    """
+    Class used for specification of a domain of instances (objects), together
+    with the operations applicable to the objects. A type may have attributes
+    and associations.
+    """
+
+    CHARACTER_STRING = "characterString"
+    """Textual infromation."""
+
+    INTEGER = "integer"
+    """Numerical field."""
+
+    ASSOCIATION = "association"
+    """
+    Semantic relationship between two classes that involves connections among
+    their instances.
+    """
 
 
 class ObligationCode(Enum):
+    """Obligation of the element or entity."""
+
     MANDATORY = "mandatory"
+    """Element is always required."""
+
     OPTIONAL = "optional"
+    """Element is not required."""
+
     CONDITIONAL = "conditional"
-    FORBIDDEN = "null"
+    """element is required when a specific condition is met."""
 
+    FORBIDDEN = None
+    """
+    The element should always be `None`. This obligation code is used only
+    when a sub-class overrides an association and force it to a `None`
+    value. An example is
+    `opengis.referencing.datum.TemporalDatum.anchor_point`.
+    """
 
-
-from opengis.metadata.citation import Citation, OnlineResource, Responsibility
 
 class ApplicationSchemaInformation(ABC):
     """Information about the application schema used to build the dataset."""
@@ -46,116 +134,176 @@ class ApplicationSchemaInformation(ABC):
     @abstractmethod
     def name(self) -> Citation:
         """Name of the application schema used."""
-        pass
 
     @property
     @abstractmethod
     def schema_language(self) -> str:
         """Identification of the schema language used."""
-        pass
 
     @property
     @abstractmethod
     def constraint_language(self) -> str:
         """Formal language used in Application Schema."""
-        pass
-
-    @property
-    def schema_ascii(self) -> str:
-        """Full application schema given as an ASCII file."""
-        return None
-
-    @property
-    def graphics_file(self) -> OnlineResource:
-        """Full application schema given as a graphics file."""
-        return None
-
-    @property
-    def software_development_file(self) -> OnlineResource:
-        """Full application schema given as a software development file."""
-        return None
-
-    @property
-    def software_development_file_format(self) -> str:
-        """Software dependent format used for the application schema software dependent file."""
-        return None
-
-
-
-class ExtendedElementInformation(ABC):
-    """New metadata element, not found in ISO 19115, which is required to describe geographic data."""
 
     @property
     @abstractmethod
-    def name(self) -> str:
-        """Name of the extended metadata element."""
-        pass
+    def schema_ascii(self) -> Optional[str]:
+        """Full application schema given as an ASCII file."""
+
+    @property
+    @abstractmethod
+    def graphics_file(self) -> Optional[OnlineResource]:
+        """Full application schema given as a graphics file."""
+
+    @property
+    @abstractmethod
+    def software_development_file(self) -> Optional[OnlineResource]:
+        """Full application schema given as a software development file."""
+
+    @property
+    @abstractmethod
+    def software_development_file_format(self) -> Optional[str]:
+        """
+        Software dependent format used for the application schema software
+        dependent file.
+        """
+
+
+class ExtendedElementInformation(ABC):
+    """
+    New metadata element, not found in ISO 19115, which is required to
+    describe geographic data.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> Optional[str]:
+        """
+        Name of the extended metadata element.
+
+        MANDATORY: if `data_type` != CODE_LIST and `datatype` != ENUMERATION
+            and `data_type` != CODE_LIST_ELEMENT.
+        """
 
     @property
     @abstractmethod
     def definition(self) -> str:
         """Definition of the extended element."""
-        pass
 
     @property
-    def obligation(self) -> ObligationCode:
-        """Obligation of the extended element."""
-        return None
+    @abstractmethod
+    def obligation(self) -> Optional[ObligationCode]:
+        """
+        Obligation of the extended element.
+
+        MANDATORY: if `data_type` != CODE_LIST and `datatype` != ENUMERATION
+            and `data_type` != CODE_LIST_ELEMENT.
+        """
 
     @property
-    def condition(self) -> str:
-        """Condition under which the extended element is mandatory."""
-        return None
+    @abstractmethod
+    def condition(self) -> Optional[str]:
+        """
+        Condition under which the extended element is mandatory.
+
+        MANDATORY: if `obligation` == .
+        """
 
     @property
     @abstractmethod
     def data_type(self) -> DatatypeCode:
-        """Code which identifies the kind of value provided in the extended element."""
-        pass
+        """
+        Code which identifies the kind of value provided in the extended
+        element.
+        """
 
     @property
-    def maximum_occurrence(self) -> int:
-        """Maximum occurrence of the extended element."""
-        return None
+    @abstractmethod
+    def maximum_occurrence(self) -> Optional[int]:
+        """
+        Maximum occurrence of the extended element.
+
+        MANDATORY: if `data_type` != CODE_LIST and `datatype` != ENUMERATION
+            and `data_type` != CODE_LIST_ELEMENT.
+        """
 
     @property
-    def domain_value(self) -> str:
-        """Valid values that can be assigned to the extended element."""
-        return None
+    @abstractmethod
+    def domain_value(self) -> Optional[str]:
+        """
+        Valid values that can be assigned to the extended element.
+
+        MANDATORY: if `data_type` != CODE_LIST and `datatype` != ENUMERATION
+            and `data_type` != CODE_LIST_ELEMENT.
+        """
 
     @property
     @abstractmethod
     def parent_entity(self) -> Sequence[str]:
-        """Name of the metadata entity(s) under which this extended metadata element may appear. The name(s) may be standard metadata element(s) or other extended metadata element(s)."""
-        pass
+        """
+        Name of the metadata entity(s) under which this extended metadata
+        element may appear. The name(s) may be standard metadata element(s) or
+        other extended metadata element(s).
+        """
 
     @property
     @abstractmethod
     def rule(self) -> str:
-        """Specifies how the extended element relates to other existing elements and entities."""
-        pass
+        """
+        Specifies how the extended element relates to other existing elements
+        and entities.
+        """
 
     @property
-    def rationale(self) -> str:
+    @abstractmethod
+    def rationale(self) -> Optional[str]:
         """Reason for creating the extended element."""
-        return None
 
     @property
     @abstractmethod
     def source(self) -> Sequence[Responsibility]:
         """Name of the person or organisation creating the extended element."""
-        pass
 
+    @property
+    @abstractmethod
+    def concept_name(self) -> Optional[str]:
+        """
+        The name of the item.
+
+        MANDATORY: if `data_type` != CODE_LIST and `datatype` != ENUMERATION
+            and `data_type` != CODE_LIST_ELEMENT.
+        """
+
+    @property
+    @abstractmethod
+    def code(self) -> Optional[str]:
+        """Language neutral identifier.
+
+        MANDATORY: if `data_type` != CODE_LIST and `datatype` != ENUMERATION
+            and `data_type` != CODE_LIST_ELEMENT.
+        """
 
 
 class MetadataExtensionInformation(ABC):
     """Information describing metadata extensions."""
 
     @property
-    def extension_on_line_resource(self) -> OnlineResource:
-        """Information about on-line sources containing the community profile name and the extended metadata elements. Information for all new metadata elements."""
-        return None
+    @abstractmethod
+    def extension_on_line_resource(self) -> Optional[OnlineResource]:
+        """
+        Information about on-line sources containing the community profile
+        name and the extended metadata elements and information for all new
+        metadata elements about on-line sources containing the community
+        profile name, the extended metadata elements and information about all
+        new metadata elements.
+        """
 
     @property
-    def extended_element_information(self) -> Sequence[ExtendedElementInformation]:
-        return None
+    @abstractmethod
+    def extended_element_information(self) -> Sequence[
+        ExtendedElementInformation
+    ]:
+        """
+        Provides information about a new metadata element, not found
+        in ISO 19115, which is required to describe the resource.
+        """

--- a/geoapi/src/main/python/opengis/metadata/extent.py
+++ b/geoapi/src/main/python/opengis/metadata/extent.py
@@ -1,75 +1,37 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the extent module.
+
+This module contains geographic metadata structures regarding data extent
+derived from the ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Optional
 
-
-
-class GeographicExtent(ABC):
-    """Spatial area of the resource."""
-
-    @property
-    def extent_type_code(self):
-        """Indication of whether the geographic element encompasses an area covered by the data or an area where data is not present."""
-        return None
-
-
-
-class GeographicBoundingBox(GeographicExtent):
-    """Geographic position of the resource. NOTE: This is only an approximate reference so specifying the coordinate reference system is unnecessary and need only be provided with a precision of up to two decimal places."""
-
-    @property
-    @abstractmethod
-    def west_bound_longitude(self) -> float:
-        """Western-most coordinate of the limit of the resource extent, expressed in longitude in decimal degrees (positive east)."""
-        pass
-
-    @property
-    @abstractmethod
-    def east_bound_longitude(self) -> float:
-        """Eastern-most coordinate of the limit of the resource extent, expressed in longitude in decimal degrees (positive east)."""
-        pass
-
-    @property
-    @abstractmethod
-    def south_bound_latitude(self) -> float:
-        """Southern-most coordinate of the limit of the resource extent, expressed in latitude in decimal degrees (positive north)."""
-        pass
-
-    @property
-    @abstractmethod
-    def north_bound_latitude(self) -> float:
-        """Northern-most, coordinate of the limit of the resource extent expressed in latitude in decimal degrees (positive north)."""
-        pass
-
-
-
+from opengis.geometry.primitive import Geometry
 from opengis.metadata.citation import Identifier
-
-class GeographicDescription(GeographicExtent):
-    """Description of the geographic area using identifiers."""
-
-    @property
-    @abstractmethod
-    def geographic_identifier(self) -> Identifier:
-        """Identifier used to represent a geographic area e.g. a geographic identifier as described in ISO 19112."""
-        pass
-
-
-
-class BoundingPolygon(GeographicExtent):
-    """Enclosing geometric object which locates the resource, expressed as a set of (x,y) coordinate (s). NOTE: If a polygon is used it should be closed (last point replicates first point)."""
-
-    @property
-    @abstractmethod
-    def polygon(self):
-        """Sets of points defining the bounding polygon or any other GM_Object geometry (point, line or polygon)."""
-        pass
-
+from opengis.referencing.crs import ReferenceSystem, VerticalCRS
 
 
 class VerticalExtent(ABC):
@@ -79,18 +41,187 @@ class VerticalExtent(ABC):
     @abstractmethod
     def minimum_value(self) -> float:
         """Lowest vertical extent contained in the resource."""
-        pass
 
     @property
     @abstractmethod
     def maximum_value(self) -> float:
         """Highest vertical extent contained in the resource."""
-        pass
 
     @property
-    def vertical_CRS(self):
-        return None
+    @abstractmethod
+    def vertical_crs(self) -> Optional[VerticalCRS]:
+        """
+        Provides information about the vertical coordinate reference system
+        to which the maximum and minimum elevation values are measured.
 
+        Identifies the vertical coordinate reference system used for the
+        minimum and maximum values.
+
+        NOTE: The CRS information includes unit of measure.
+
+        MANDATORY: if vertical_crs_id is `None`.
+        """
+
+    @property
+    @abstractmethod
+    def vertical_crs_id(self) -> Optional[ReferenceSystem]:
+        """
+        Identifies the vertical coordinate reference system used for the
+        minimum and maximum values.
+
+        MANDATORY: if vertical_crs is `None`.
+        """
+
+
+class Extent(ABC):
+    """Extent of the resource."""
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """
+        Extent of the referring object.
+
+        Sets of points defining the bounding polygon or any other
+        geometry (point, line or polygon).
+
+        MANDATORY: if `geographic_element`, `temproal_element`,
+            and `vertical_element` are `None`.
+        """
+
+    @property
+    @abstractmethod
+    def geographic_element(self) -> Optional[Sequence['GeographicExtent']]:
+        """
+        Provides spatial component of the extent of the referring object.
+
+        MANDATORY: if `description`, `temproal_element`,
+            and `vertical_element` are `None`.
+        """
+
+    @property
+    @abstractmethod
+    def temporal_element(self) -> Optional[Sequence['TemporalExtent']]:
+        """
+        Provides temporal component of the extent of the referring object.
+
+        MANDATORY: if `description`, `geographic_element`,
+            and `vertical_element` are `None`.
+        """
+
+    @property
+    @abstractmethod
+    def vertical_element(self) -> Optional[Sequence[VerticalExtent]]:
+        """
+        Provides vertical component of the extent of the referring object.
+
+        MANDATORY: if `description`, `geographic_element`,
+            and `temporal_element` are `None`.
+        """
+
+
+class GeographicExtent(ABC):
+    """Spatial area of the resource."""
+
+    @property
+    @abstractmethod
+    def extent_type_code(self) -> bool:
+        """
+        Indication of whether the geographic element encompasses an area
+        covered by the data or an area where data is not present.
+
+        Default: `True`
+
+        Domain:
+            `False` = 0 = exclusion
+            `True`  = 1 = inclusion
+        """
+
+
+class BoundingPolygon(GeographicExtent):
+    """
+    Encosing geometric onject which locates the resource, expressed as a set
+    of (x,y) coordinate(s).
+
+    NOTE 1: If a polygon is used it should be closed (i.e. the last point
+    replicates the first point).
+
+    NOTE 2: This type can be used to represent geometries other than polygons,
+    e.g., points, lines.
+    """
+
+    @property
+    @abstractmethod
+    def polygon(self) -> Sequence[Geometry]:
+        """
+        Sets of points defining the bounding polygon or any other `Geometry`
+        object (point, line, or polygon).
+        """
+
+
+class GeographicBoundingBox(GeographicExtent):
+    """
+    Geographic position of the resource.
+
+    NOTE: This is only an approximate reference so specifying the coordinate
+    reference system is unnecessary and need only be provided with a precision
+    of up to two decimal places.
+    """
+
+    @property
+    @abstractmethod
+    def west_bound_longitude(self) -> float:
+        """
+        Western-most coordinate of the limit of the resource extent, expressed
+        in longitude in decimal degrees (positive east).
+
+        Domain: -180.0 <= West Bounding Logitude Value <= 180.0
+        """
+
+    @property
+    @abstractmethod
+    def east_bound_longitude(self) -> float:
+        """
+        Eastern-most coordinate of the limit of the resource extent, expressed
+        in longitude in decimal degrees (positive east).
+
+        Domain: -180.0 <= East Bounding Logitude Value <= 180.0
+        """
+
+    @property
+    @abstractmethod
+    def south_bound_latitude(self) -> float:
+        """
+        Southern-most coordinate of the limit of the resource extent,
+        expressed in latitude in decimal degrees (positive north).
+
+        Domain: -90.0 <= South Bounding Latitude Value <= 90.0;
+            South Bouding Latitude Value <= North Bounding Latitude Value
+        """
+
+    @property
+    @abstractmethod
+    def north_bound_latitude(self) -> float:
+        """
+        Northern-most, coordinate of the limit of the resource extent
+        expressed in latitude in decimal degrees (positive north).
+
+        Domain: -90.0 <= North Bounding Latitude Value <= 90.0;
+            North Bouding Latitude Value >= South Bounding Latitude Value
+        """
+
+
+class GeographicDescription(GeographicExtent):
+    """Description of the geographic area using identifiers."""
+
+    @property
+    @abstractmethod
+    def geographic_identifier(self) -> Identifier:
+        """
+        Identifier used to represent a geographic area.
+
+        NOTE: a geographic identifier as described in ISO 19112.
+        """
 
 
 class TemporalExtent(ABC):
@@ -98,43 +229,27 @@ class TemporalExtent(ABC):
 
     @property
     @abstractmethod
-    def extent(self):
-        """Period for the content of the resource."""
-        pass
+    def extent(self) -> tuple[datetime, datetime]:
+        """
+        Period for the content of the resource.
 
+        Returns a tuple with the first component being the beginning `datetime`
+        of the temporal period and the second component being the end
+        `datetime`.
+        """
 
 
 class SpatialTemporalExtent(TemporalExtent):
     """Extent with respect to date/time and spatial boundaries."""
 
     @property
+    @abstractmethod
     def vertical_extent(self) -> VerticalExtent:
         """Vertical extent component."""
-        return None
 
     @property
     @abstractmethod
     def spatial_extent(self) -> Sequence[GeographicExtent]:
-        pass
-
-
-
-class Extent(ABC):
-    """Extent of the resource."""
-
-    @property
-    def description(self) -> str:
-        """Sets of points defining the bounding polygon or any other GM_Object geometry (point, line or polygon)."""
-        return None
-
-    @property
-    def geographic_element(self) -> Sequence[GeographicExtent]:
-        return None
-
-    @property
-    def temporal_element(self) -> Sequence[TemporalExtent]:
-        return None
-
-    @property
-    def vertical_element(self) -> Sequence[VerticalExtent]:
-        return None
+        """
+        Spatial extent component of a composite spatial and temporal extent.
+        """

--- a/geoapi/src/main/python/opengis/metadata/identification.py
+++ b/geoapi/src/main/python/opengis/metadata/identification.py
@@ -1,422 +1,937 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the identification module.
+
+This module contains geographic metadata structures regarding identification
+information codelists and common base classes derived from the
+ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import datetime, timedelta
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import (
+    Citation,
+    Identifier,
+    OnlineResource,
+    Responsibility,
+)
+from opengis.metadata.constraints import Constraints
+from opengis.metadata.distribution import Format
+from opengis.metadata.extent import Extent
+from opengis.metadata.maintenance import MaintenanceInformation
+from opengis.metadata.representation import SpatialRepresentationTypeCode
+from opengis.util.measure import Angle, Distance
 
 
 class AssociationTypeCode(Enum):
-    CROSS_REFERENCE = "crossReference"
-    LARGER_WORK_CITATION = "largerWorkCitation"
-    PART_OF_SEAMLESS_DATABASE = "partOfSeamlessDatabase"
-    SOURCE = "source"
-    STEREO_MATE = "stereoMate"
-    IS_COMPOSED_OF = "isComposedOf"
-    COLLECTIVE_TITLE = "collectiveTitle"
-    SERIES = "series"
-    DEPENDENCY = "dependency"
-    REVISION_OF = "revisionOf"
+    """Justification for the correlation of two resources."""
 
+    CROSS_REFERENCE = "crossReference"
+    """Reference from one resource to another."""
+
+    LARGER_WORK_CITATION = "largerWorkCitation"
+    """Reference to a master resource of which this one is a part."""
+
+    PART_OF_SEAMLESS_DATABASE = "partOfSeamlessDatabase"
+    """Part of same structured set of data held in a computer."""
+
+    # deprecated Removed in ISO 19115:2014.
+    # SOURCE = "source"
+    # """
+    # Mapping and charting information from which the dataset content
+    # originates.
+    # """
+
+    STEREO_MATE = "stereoMate"
+    """
+    Part of a set of imagery that when used together, provides
+    three-dimensional images.
+    """
+
+    IS_COMPOSED_OF = "isComposedOf"
+    """Reference to resources that are parts of this resource."""
+
+    COLLECTIVE_TITLE = "collectiveTitle"
+    """
+    Common title for a collection of resources.
+
+    NOTE: Title identifies elements of a series collectively, combined with
+    information about what volumes are available at the source cite.
+    """
+
+    SERIES = "series"
+    """
+    Associated through a common heritage such as produced to a common product
+    specification.
+    """
+
+    DEPENDENCY = "dependency"
+    """Associated through a dependency."""
+
+    REVISION_OF = "revisionOf"
+    """Resource is a revision of associated resource."""
 
 
 class InitiativeTypeCode(Enum):
-    CAMPAIGN = "campaign"
-    COLLECTION = "collection"
-    EXERCISE = "exercise"
-    EXPERIMENT = "experiment"
-    INVESTIGATION = "investigation"
-    MISSION = "mission"
-    SENSOR = "sensor"
-    OPERATION = "operation"
-    PLATFORM = "platform"
-    PROCESS = "process"
-    PROGRAM = "program"
-    PROJECT = "project"
-    STUDY = "study"
-    TASK = "task"
-    TRIAL = "trial"
+    """Type of aggregation activity in which resources are related."""
 
+    CAMPAIGN = "campaign"
+    """Series of organized planned actions."""
+
+    COLLECTION = "collection"
+    """Accumulation of resources assembled for a specific purpose."""
+
+    EXERCISE = "exercise"
+    """Specific performance of a function or group of functions."""
+
+    EXPERIMENT = "experiment"
+    """Process designed to find if something is effective or valid."""
+
+    INVESTIGATION = "investigation"
+    """Search or systematic inquiry."""
+
+    MISSION = "mission"
+    """Specific operation of a data collection system."""
+
+    SENSOR = "sensor"
+    """Device or piece of equipment which detects or records."""
+
+    OPERATION = "operation"
+    """Action that is part of a series of actions."""
+
+    PLATFORM = "platform"
+    """Vehicle or other support base that holds a sensor."""
+
+    PROCESS = "process"
+    """Method of doing something involving a number of steps."""
+
+    PROGRAM = "program"
+    """Specific planned activity."""
+
+    PROJECT = "project"
+    """Organized undertaking, research, or development."""
+
+    STUDY = "study"
+    """Examination or investigation."""
+
+    TASK = "task"
+    """Piece of work."""
+
+    TRIAL = "trial"
+    """Process of testing to discover or demonstrate something."""
 
 
 class KeywordTypeCode(Enum):
-    DISCIPLINE = "discipline"
-    PLACE = "place"
-    STRATUM = "stratum"
-    TEMPORAL = "temporal"
-    THEME = "theme"
-    DATA_CENTRE = "dataCentre"
-    FEATURE_TYPE = "featureType"
-    INSTRUMENT = "instrument"
-    PLATFORM = "platform"
-    PROCESS = "process"
-    PROJECT = "project"
-    SERVICE = "service"
-    PRODUCT = "product"
-    SUB_TOPIC_CATEGORY = "subTopicCategory"
-    TAXON = "taxon"
+    """Methods used to group similar keywords."""
 
+    DISCIPLINE = "discipline"
+    """Keyword identifies a branch of instruction or specialized learning."""
+
+    PLACE = "place"
+    """Keyword identifies a location."""
+
+    STRATUM = "stratum"
+    """
+    Keyword identifies the layer(s) of any deposited substance or levels
+    within an ordered system.
+    """
+
+    TEMPORAL = "temporal"
+    """Keyword identifies a time period related to the resource."""
+
+    THEME = "theme"
+    """Keyword identifies a particular subject or topic."""
+
+    DATA_CENTRE = "dataCentre"
+    """
+    Keyword identifies a repository or archive that manages and
+    distributes data.
+    """
+
+    FEATURE_TYPE = "featureType"
+    """
+    Keyword identifies a resource containing or about a collection of feature
+    instances with common characteristics.
+    """
+
+    INSTRUMENT = "instrument"
+    """
+    Keyword identifies a device used to measure or compare physical properties.
+    """
+
+    PLATFORM = "platform"
+    """Keyword identifies a structure upon which an instrument is mounted."""
+
+    PROCESS = "process"
+    """Keyword identifies a series of actions or natural occurrences."""
+
+    PROJECT = "project"
+    """
+    Keyword identifies an endeavour undertaken to create or modify a product
+    or service.
+    """
+
+    SERVICE = "service"
+    """
+    Keyword identifies an activity carried out by one party for the benefit
+    of another.
+    """
+
+    PRODUCT = "product"
+    """Keyword identifies a type of product."""
+
+    SUB_TOPIC_CATEGORY = "subTopicCategory"
+    """
+    Refinement of a topic category for the purpose of geographic
+    data classification.
+    """
+
+    TAXON = "taxon"
+    """Keyword identifies a taxonomy of the resource."""
 
 
 class ProgressCode(Enum):
-    COMPLETED = "completed"
-    HISTORICAL_ARCHIVE = "historicalArchive"
-    OBSOLETE = "obsolete"
-    ON_GOING = "onGoing"
-    PLANNED = "planned"
-    REQUIRED = "required"
-    UNDER_DEVELOPMENT = "underDevelopment"
-    FINAL = "final"
-    PENDING = "pending"
-    RETIRED = "retired"
-    SUPERSEDED = "superseded"
-    TENTATIVE = "tentative"
-    VALID = "valid"
-    ACCEPTED = "accepted"
-    NOT_ACCEPTED = "notAccepted"
-    WITHDRAWN = "withdrawn"
-    PROPOSED = "proposed"
-    DEPRECATED = "deprecated"
+    """Status of the resource."""
 
+    COMPLETED = "completed"
+    """Has been completed."""
+
+    HISTORICAL_ARCHIVE = "historicalArchive"
+    """Stored in an offline storage facility."""
+
+    OBSOLETE = "obsolete"
+    """No longer relevant."""
+
+    ON_GOING = "onGoing"
+    """Continually being updated."""
+
+    PLANNED = "planned"
+    """
+    Fixed date has been established upon or by which the resource will be
+    created or updated.
+    """
+
+    REQUIRED = "required"
+    """Needs to be generated or updated."""
+
+    UNDER_DEVELOPMENT = "underDevelopment"
+    """Currently in the process of being created."""
+
+    FINAL = "final"
+    """Progress concluded and no changes will be accepted."""
+
+    PENDING = "pending"
+    """Committed to, but not yet addressed."""
+
+    RETIRED = "retired"
+    """
+    Item is no longer recommended for use. It has not been superseded
+    by another item.
+    """
+
+    SUPERSEDED = "superseded"
+    """Replaced by new."""
+
+    TENTATIVE = "tentative"
+    """Provisional changes likely before resource becomes final or complete."""
+
+    VALID = "valid"
+    """Acceptable under specific conditions."""
+
+    ACCEPTED = "accepted"
+    """Agreed to by sponsor."""
+
+    NOT_ACCEPTED = "notAccepted"
+    """Rejected by sponsor."""
+
+    WITHDRAWN = "withdrawn"
+    """Removed from consideration."""
+
+    PROPOSED = "proposed"
+    """Suggested that development needs to be undertaken."""
+
+    DEPRECATED = "deprecated"
+    """
+    Resource superseded and will become obsolete, use only
+    for historical purposes.
+    """
 
 
 class TopicCategoryCode(Enum):
+    """
+    High-level geographic data thematic classification to assist in the
+    grouping and search of available geographic datasets.
+
+    NOTE 1: Can be used to group keywords as well. Listed examples are not
+    exhaustive.
+
+    NOTE 2: Is is understto there are overlaps between general categories and
+    the user is encouraged to select the one most appropriate.
+    """
+
     FARMING = "farming"
+    """
+    Rearing of animals and/or cultivation of plants.
+
+    EXAMPLES: Agriculture, irrigation, aquaculture, plantations, herding,
+    pests and diseases affecting crops and livestock.
+    """
+
     BIOTA = "biota"
+    """
+    Flora and/or fauna in natural environment.
+
+    EXAMPLES: Wildlife, vegetation, biological sciences, ecology, wilderness,
+    sealife, wetlands, habitat.
+    """
+
     BOUNDARIES = "boundaries"
+    """
+    Legal land descriptions, maritime boundaries.
+
+    EXAMPLES: Political and administrative boundaries, territorial seas, EEZ,
+    port security zones.
+    """
+
     CLIMATOLOGY_METEOROLOGY_ATMOSPHERE = "climatologyMeteorologyAtmosphere"
+    """
+    Processes and phenomena of the atmosphere.
+
+    EXAMPLES: Cloud cover, weather, climate, atmospheric conditions,
+    climate change, precipitation.
+    """
+
     ECONOMY = "economy"
+    """
+    Economic activities, conditions and employment.
+
+    EXAMPLES: Production, labour, revenue, commerce, industry, tourism and
+    ecotourism, forestry, fisheries, commercial or subsistence hunting,
+    exploration and exploitation of resources such as minerals, oil and gas.
+    """
+
     ELEVATION = "elevation"
+    """
+    Height above or below a vertical datum.
+
+    EXAMPLES: Altitude, bathymetry, digital elevation models, slope,
+    derived products.
+    """
+
     ENVIRONMENT = "environment"
+    """
+    Environmental resources, protection and conservation.
+
+    EXAMPLES: Environmental pollution, waste storage and treatment,
+    environmental impact assessment, monitoring environmental risk,
+    nature reserves, landscape.
+    """
+
     GEOSCIENTIFIC_INFORMATION = "geoscientificInformation"
+    """
+    Information pertaining to earth sciences.
+
+    EXAMPLES: Geophysical features and processes, geology, minerals,
+    sciences dealing with the composition, structure and origin of the
+    Earth's rocks, risks of earthquakes, volcanic activity, landslides,
+    gravity information, soils, permafrost, hydrogeology, erosion.
+    """
+
     HEALTH = "health"
+    """
+    Health, health services, human ecology, and safety.
+
+    EXAMPLES: Disease and illness, factors affecting health, hygiene,
+    substance abuse, mental and physical health, health services.
+    """
+
     IMAGERY_BASE_MAPS_EARTH_COVER = "imageryBaseMapsEarthCover"
+    """
+    Base maps.
+
+    EXAMPLES: Land cover, topographic maps, imagery, unclassified images,
+    annotations.
+    """
+
     INTELLIGENCE_MILITARY = "intelligenceMilitary"
+    """
+    Military bases, structures, activities.
+
+    EXAMPLES: Barracks, training grounds, military transportation,
+    information collection.
+    """
+
     INLAND_WATERS = "inlandWaters"
+    """
+    Inland water features, drainage systems and their characteristics.
+
+    EXAMPLES: Rivers and glaciers, salt lakes, water utilization plans, dams,
+    currents, floods, water quality, hydrologic information.
+    """
+
     LOCATION = "location"
+    """
+    Positional information and services.
+
+    EXAMPLES: Addresses, geodetic networks, control points, postal zones and
+    services, place names.
+    """
+
     OCEANS = "oceans"
+    """
+    Features and characteristics of salt water bodies (excluding inland waters).
+
+    EXAMPLES: Tides, tsunamis, coastal information, reefs.
+    """
+
     PLANNING_CADASTRE = "planningCadastre"
+    """
+    Information used for appropriate actions for future use of the land.
+
+    EXAMPLES: Land use maps, zoning maps, cadastral surveys, land ownership.
+    """
+
     SOCIETY = "society"
+    """
+    Characteristics of society and cultures.
+
+    EXAMPLES: Settlements, anthropology, archaeology, education,
+    traditional beliefs, manners and customs, demographic data,
+    recreational areas and activities, social impact assessments,
+    crime and justice, census information.
+    """
+
     STRUCTURE = "structure"
+    """
+    Man-made construction.
+
+    EXAMPLES: Buildings, museums, churches, factories, housing, monuments,
+    shops, towers.
+    """
+
     TRANSPORTATION = "transportation"
+    """
+    Means and aids for conveying persons and/or goods.
+
+    EXAMPLES: Roads, airports/airstrips, shipping routes, tunnels,
+    nautical charts, vehicle or vessel location, aeronautical charts,
+    railways.
+    """
+
     UTILITIES_COMMUNICATION = "utilitiesCommunication"
+    """
+    Energy, water and waste systems and communications infrastructure
+    and services.
+
+    EXAMPLES: Hydroelectricity, geothermal, solar and nuclear sources
+    of energy, water purification and distribution, sewage collection and
+    disposal, electricity and gas distribution, data communication,
+    telecommunication, radio, communication networks.
+    """
+
     EXTRA_TERRESTRIAL = "extraTerrestrial"
+    """Region more than 100 km above the surface of the Earth."""
+
     DISASTER = "disaster"
+    """
+    Information related to disasters.
 
+    EXAMPLES: Site of the disaster, evacuation zone,
+    disaster-prevention facility, disaster relief activities.
+    """
 
-
-from opengis.metadata.constraints import Constraints
-from opengis.metadata.citation import OnlineResource, Citation, Responsibility, Identifier
 
 class BrowseGraphic(ABC):
-    """Graphic that provides an illustration of the dataset (should include a legend for the graphic, if applicable)."""
+    """
+    Graphic that provides an illustration of a resource/dataset
+
+    NOTE: should include a legend for the graphic, if applicable.
+
+    Example: A dataset, an organisation logo, security constraint, or citation
+    graphic.
+    """
 
     @property
     @abstractmethod
-    def file_name(self):
-        """Name of the file that contains a graphic that provides an illustration of the dataset."""
-        pass
+    def file_name(self) -> str:
+        """
+        Name of the file that contains a graphic that provides an illustration
+        of the resource/dataset.
+        """
 
     @property
-    def file_description(self) -> str:
+    @abstractmethod
+    def file_description(self) -> Optional[str]:
         """Text description of the illustration."""
-        return None
 
     @property
-    def file_type(self) -> str:
-        """Format in which the illustration is encoded."""
-        return None
+    @abstractmethod
+    def file_type(self) -> Optional[str]:
+        """
+        Format in which the illustration is encoded.
+
+        Example: EPS, GIF, JPEG, PBM, PS, TIFF, PDF.
+        """
 
     @property
-    def image_constraints(self) -> Sequence[Constraints]:
+    @abstractmethod
+    def image_constraints(self) -> Optional[Sequence[Constraints]]:
         """Restriction on access and/or use of browse graphic."""
-        return None
 
     @property
-    def linkage(self) -> Sequence[OnlineResource]:
+    @abstractmethod
+    def linkage(self) -> Optional[Sequence[OnlineResource]]:
         """Link to browse graphic."""
-        return None
-
 
 
 class KeywordClass(ABC):
-    """Specification of a class to categorize keywords in a domain-specific vocabulary that has a binding to a formal ontology."""
+    """
+    Specification of a class to categorize keywords in a domain-specific
+    vocabulary that has a binding to a formal ontology.
+    """
 
     @property
     @abstractmethod
     def class_name(self) -> str:
-        """Character string to label the keyword category in natural language."""
-        pass
+        """
+        Character string to label the keyword category in natural language.
+        """
 
     @property
-    def concept_identifier(self):
-        """URI of concept in ontology specified by the ontology attribute; this concept is labeled by the className: CharacterString."""
-        return None
+    @abstractmethod
+    def concept_identifier(self) -> Optional[str]:
+        """
+        URI (as a string) of concept in ontology specified by the ontology
+        attribute; this concept is labeled by the className:
+        CharacterString.
+        """
 
     @property
     @abstractmethod
     def ontology(self) -> Citation:
-        """A reference that binds the keyword class to a formal conceptualization of a knowledge domain for use in semantic processingNOTE: Keywords in the associated MD_Keywords keyword list must be within the scope of this ontology."""
-        pass
-
+        """
+        A reference that binds the keyword class to a formal conceptualization
+        of a knowledge domain for use in semantic processing NOTE: Keywords in
+        the associated `Keywords` keyword list must be within the scope of
+        this ontology.
+        """
 
 
 class Keywords(ABC):
-    """Keywords, their type and reference source. NOTE: When the resource described is a service, one instance of MD_Keyword shall refer to the service taxonomy defined in ISO 19119, 8.3)."""
+    """
+    Keywords, their type and reference source.
+
+        NOTE: When the resource
+    described is a service, one instance of `Keyword` shall refer to the
+    service taxonomy defined in ISO 19119, 8.3).
+    """
 
     @property
     @abstractmethod
     def keyword(self) -> Sequence[str]:
-        """Commonly used word(s) or formalised word(s) or phrase(s) used to describe the subject."""
-        pass
+        """
+        Commonly used word(s) or formalised word(s) or phrase(s) used to
+        describe the subject.
+        """
 
     @property
-    def type(self) -> KeywordTypeCode:
+    @abstractmethod
+    def type(self) -> Optional[KeywordTypeCode]:
         """Subject matter used to group similar keywords."""
-        return None
 
     @property
-    def thesaurus_name(self) -> Citation:
-        """Name of the formally registered thesaurus or a similar authoritative source of keywords."""
-        return None
+    @abstractmethod
+    def thesaurus_name(self) -> Optional[Citation]:
+        """
+        Name of the formally registered thesaurus or a similar authoritative
+        source of keywords.
+        """
 
     @property
-    def keyword_class(self) -> KeywordClass:
-        return None
+    @abstractmethod
+    def keyword_class(self) -> Optional[KeywordClass]:
+        """
+        Association of an `Keywords` instance with an `KeywordClass` to
+        provide user-defined categorization of groups of keywords that extend
+        or are orthogonal to the standardized KeywordTypeCodes and are
+        associated with an ontology that allows additional semantic query
+        processing.
 
+        NOTE: The thesaurus citation specifies a collection of
+        instances from some ontology, but is not an ontology. It might be a
+        list of places that include rivers, mountains, counties and cities.
+        There might be a Laconte County, the city Laconte, the Laconte River,
+        and Mt. Laconte; when searching it is useful for the user to be able to
+        restrict the search to rivers only.
+        """
 
-
-from datetime import datetime
 
 class Usage(ABC):
-    """Brief description of ways in which the resource(s) is/are currently or has been used."""
+    """
+    Brief description of ways in which the resource(s) is/are currently or has
+    been used.
+    """
 
     @property
     @abstractmethod
     def specific_usage(self) -> str:
         """Brief description of the resource and/or resource series usage."""
-        pass
 
     @property
-    def usage_date_time(self) -> datetime:
-        """Date and time of the first use or range of uses of the resource and/or resource series."""
-        return None
+    @abstractmethod
+    def usage_date_time(self) -> Optional[Sequence[datetime]]:
+        """
+        Date and time of the first use or range of uses of the resource and/or
+        resource series.
+        """
 
     @property
+    @abstractmethod
     def user_determined_limitations(self) -> str:
-        """Applications, determined by the user for which the resource and/or resource series is not suitable."""
-        return None
+        """
+        Applications, determined by the user for which the resource and/or
+        resource series is not suitable.
+        """
 
     @property
-    def user_contact_info(self) -> Sequence[Responsibility]:
-        """Identification of and means of communicating with person(s) and organisation(s) using the resource(s)."""
-        return None
+    @abstractmethod
+    def user_contact_info(self) -> Optional[Sequence[Responsibility]]:
+        """
+        Identification of and means of communicating with person(s) and
+        organisation(s) using the resource(s).
+        """
 
     @property
-    def response(self) -> Sequence[str]:
-        """Response to the user-determined limitationsE.G.. 'this has been fixed in version x'."""
-        return None
+    @abstractmethod
+    def response(self) -> Optional[Sequence[str]]:
+        """
+        Response to the user-determined limitations, e.g., 'This has been fixed
+        in version x.'
+        """
 
     @property
-    def additional_documentation(self) -> Sequence[Citation]:
-        return None
+    @abstractmethod
+    def additional_documentation(self) -> Optional[Sequence[Citation]]:
+        """Publications that describe usage of data."""
 
     @property
-    def identified_issues(self) -> Sequence[Citation]:
-        return None
-
+    @abstractmethod
+    def identified_issues(self) -> Optional[Sequence[Citation]]:
+        """
+        Citation of a description of known issues associated with the resource
+        along with proposed solutions if available.
+        """
 
 
 class RepresentativeFraction(ABC):
-    """Derived from ISO 19103 Scale where MD_RepresentativeFraction.denominator = 1 / Scale.measure And Scale.targetUnits = Scale.sourceUnits."""
+    """
+    Derived from ISO 19103 Scale where
+    `denominator` = 1 / `Scale.measure`
+    and `Scale.target_units` = `Scale.source_units`.
+    """
 
     @property
     @abstractmethod
     def denominator(self) -> int:
-        """The number below the line in a vulgar fraction."""
-        pass
+        """
+        The number below the line in a vulgar fraction.
 
+        Domain: > 0
+        """
 
 
 class Resolution(ABC):
     """Level of detail expressed as a scale factor, a distance or an angle."""
 
     @property
-    def equivalent_scale(self) -> RepresentativeFraction:
-        """Level of detail expressed as the scale of a comparable hardcopy map or chart."""
-        return None
+    @abstractmethod
+    def equivalent_scale(self) -> Optional[RepresentativeFraction]:
+        """
+        Level of detail expressed as the scale of a comparable hardcopy map or
+        chart.
+
+        MANDATORY: if `distance`, `vertical`, `angular_distance`,
+            or `level_of_detail` not documented.
+        """
 
     @property
-    def distance(self) -> float:
-        """Horizontal ground sample distance."""
-        return None
+    @abstractmethod
+    def distance(self) -> Optional[Distance]:
+        """
+        Horizontal ground sample distance.
+
+        MANDATORY: if `equivalent_scale`, `vertical`, `angular_distance`,
+            or `level_of_detail` not documented.
+        """
 
     @property
-    def vertical(self) -> float:
-        """Vertical sampling distance."""
-        return None
+    @abstractmethod
+    def vertical(self) -> Optional[Distance]:
+        """
+        Vertical sampling distance.
+
+        MANDATORY: if `equivalent_scale`, `distance`, `angular_distance`,
+            or `level_of_detail` not documented.
+        """
 
     @property
-    def angular_distance(self) -> float:
-        """Angular sampling measure."""
-        return None
+    @abstractmethod
+    def angular_distance(self) -> Optional[Angle]:
+        """
+        Angular sampling measure.
+
+        MANDATORY: if `equivalent_scale`, `distance`, `vertical`,
+            or `level_of_detail` not documented.
+        """
 
     @property
-    def level_of_detail(self) -> str:
-        """Brief textual description of the spatial resolution of the resource."""
-        return None
+    @abstractmethod
+    def level_of_detail(self) -> Optional[str]:
+        """
+        Brief textual description of the spatial resolution of the resource.
 
+        MANDATORY: if `equivalent_scale`, `distance`, `vertical`,
+            or `angular_distance` not documented.
+        """
 
 
 class AssociatedResource(ABC):
-    """Associated resource information. NOTE: An associated resource is a dataset composed of a collection of datasets."""
+    """
+    Associated resource information.
+
+    NOTE: An associated resource is a dataset composed of a collection
+    of datasets.
+    """
 
     @property
-    def name(self) -> Citation:
-        """Citation information about the associated resource."""
-        return None
+    @abstractmethod
+    def name(self) -> Optional[Citation]:
+        """
+        Citation information about the associated resource.
+
+        MANDATORY: if `metadata_reference` not documented.
+        """
 
     @property
     @abstractmethod
     def association_type(self) -> AssociationTypeCode:
         """Type of relation between the resources."""
-        pass
 
     @property
-    def initiative_type(self) -> InitiativeTypeCode:
-        """Type of initiative under which the associated resource was produced. NOTE: the activity that resulted in the associated resource."""
-        return None
+    @abstractmethod
+    def initiative_type(self) -> Optional[InitiativeTypeCode]:
+        """
+        Type of initiative under which the associated resource was produced.
+
+        NOTE: the activity that resulted in the associated resource.
+        """
 
     @property
-    def metadata_reference(self) -> Citation:
-        """Reference to the metadata of the associated resource."""
-        return None
+    @abstractmethod
+    def metadata_reference(self) -> Optional[Citation]:
+        """
+        Reference to the metadata of the associated resource.
 
+        MANDATORY: if `name` not documented.
+        """
 
-
-from opengis.metadata.representation import SpatialRepresentationTypeCode
-from opengis.metadata.extent import Extent
-from opengis.metadata.maintenance import MaintenanceInformation
-from opengis.metadata.distribution import Format
 
 class Identification(ABC):
-    """Basic information required to uniquely identify a resource or resources."""
+    """
+    Basic information required to uniquely identify a resource or resources.
+    """
 
     @property
     @abstractmethod
     def citation(self) -> Citation:
         """Citation for the resource(s)."""
-        pass
 
     @property
     @abstractmethod
     def abstract(self) -> str:
         """Brief narrative summary of the content of the resource(s)."""
-        pass
+
+    @abstractmethod
+    def purpose(self) -> Optional[str]:
+        """
+        Summary of the intentions with which the resource(s) was developed.
+        """
 
     @property
-    def purpose(self) -> str:
-        """Summary of the intentions with which the resource(s) was developed."""
-        return None
-
-    @property
-    def credit(self) -> Sequence[str]:
+    @abstractmethod
+    def credit(self) -> Optional[Sequence[str]]:
         """Recognition of those who contributed to the resource(s)."""
-        return None
 
     @property
-    def status(self) -> Sequence[ProgressCode]:
+    @abstractmethod
+    def status(self) -> Optional[Sequence[ProgressCode]]:
         """Status of the resource(s)."""
-        return None
 
     @property
-    def point_of_contact(self) -> Sequence[Responsibility]:
-        """Identification of, and means of communication with, person(s) and organisation(s) associated with the resource(s)."""
-        return None
+    @abstractmethod
+    def point_of_contact(self) -> Optional[Sequence[Responsibility]]:
+        """
+        Identification of, and means of communication with, person(s) and
+        organisation(s) associated with the resource(s).
+        """
 
     @property
-    def spatial_representation_type(self) -> Sequence[SpatialRepresentationTypeCode]:
+    @abstractmethod
+    def spatial_representation_type(self) -> Optional[Sequence[
+        SpatialRepresentationTypeCode
+    ]]:
         """Method used to spatially represent geographic information."""
-        return None
 
     @property
-    def spatial_resolution(self) -> Sequence[Resolution]:
-        """Factor which provides a general understanding of the density of spatial data in the resource."""
-        return None
+    @abstractmethod
+    def spatial_resolution(self) -> Optional[Sequence[Resolution]]:
+        """
+        Factor which provides a general understanding of the density of
+        spatial data in the resource.
+        """
 
     @property
-    def temporal_resolution(self):
-        """Resolution of the resource with respect to time."""
-        return None
+    @abstractmethod
+    def temporal_resolution(self) -> Optional[Sequence[timedelta]]:
+        """Smallest resolvable temporal period in a resource."""
 
     @property
-    def topic_category(self) -> Sequence[TopicCategoryCode]:
-        """Main theme(s) of the resource."""
-        return None
+    @abstractmethod
+    def topic_category(self) -> Optional[Sequence[TopicCategoryCode]]:
+        """
+        Main theme(s) of the resource.
+
+        MANDATORY: if `Metadata.metadata_scope.resource_scope` == 'dataset'
+            OR `Metadata.metadata_scope.resource_scope` == 'series'.
+        """
 
     @property
-    def extent(self) -> Sequence[Extent]:
-        """Spatial and temporal extent of the resource."""
-        return None
+    @abstractmethod
+    def extent(self) -> Optional[Sequence[Extent]]:
+        """
+        Spatial and temporal extent of the resource.
+
+        MANDATORY: if `Metadata.metadata_scope.resource_scope` == 'dataset'
+            then `extent.geographic_element.GeographicBoundingBox`
+            or  `extent.geographic_element.Geographicdescription` is required.
+        """
 
     @property
-    def additional_documentation(self) -> Sequence[Citation]:
-        """Other documentation associated with the resource."""
-        return None
+    @abstractmethod
+    def additional_documentation(self) -> Optional[Sequence[Citation]]:
+        """
+        Other documentation associated with the resource, e.g.,
+        Related articles, publications, user guides, data dictionaries.
+        """
 
     @property
-    def processing_level(self) -> Identifier:
-        """Code that identifies the level of processing in the producers coding system of a resource eg. NOAA level 1B."""
-        return None
+    @abstractmethod
+    def processing_level(self) -> Optional[Identifier]:
+        """
+        Code that identifies the level of processing in the producers coding
+        system of a resource, e.g., NOAA level 1B.
+        """
 
     @property
-    def resource_maintenance(self) -> Sequence[MaintenanceInformation]:
-        return None
+    @abstractmethod
+    def resource_maintenance(self) -> Optional[Sequence[
+        MaintenanceInformation
+    ]]:
+        """
+        Information about the frequency of resource updates and the scope of
+        those updates.
+        """
 
     @property
-    def graphic_overview(self) -> Sequence[BrowseGraphic]:
-        return None
+    @abstractmethod
+    def graphic_overview(self) -> Optional[Sequence[BrowseGraphic]]:
+        """
+        Graphic that illustrates the resource (should include a legend for
+        the graphic).
+        """
 
     @property
-    def resource_format(self) -> Sequence[Format]:
-        return None
+    @abstractmethod
+    def resource_format(self) -> Optional[Sequence[Format]]:
+        """Description of the format of the resource."""
 
     @property
-    def descriptive_keywords(self) -> Sequence[Keywords]:
-        return None
+    @abstractmethod
+    def descriptive_keywords(self) -> Optional[Sequence[Keywords]]:
+        """Category keywords, their type, and reference source."""
 
     @property
-    def resource_specific_usage(self) -> Sequence[Usage]:
-        return None
+    @abstractmethod
+    def resource_specific_usage(self) -> Optional[Sequence[Usage]]:
+        """
+        Basic information about specific application(s) for which the resource
+        has been or is being used by different users.
+        """
 
     @property
-    def resource_constraints(self) -> Sequence[Constraints]:
-        return None
+    @abstractmethod
+    def resource_constraints(self) -> Optional[Sequence[Constraints]]:
+        """Information about constraints which apply to the resource."""
 
     @property
-    def associated_resource(self) -> Sequence[AssociatedResource]:
-        return None
-
+    @abstractmethod
+    def associated_resource(self) -> Optional[Sequence[AssociatedResource]]:
+        """Associated resource information."""
 
 
 class DataIdentification(Identification):
     """Information required to identify a resource."""
 
     @property
-    def default_locale(self):
-        """Provides information about an alternatively used localized character string for a linguistic extension."""
-        return None
+    @abstractmethod
+    def default_locale(self) -> Optional[str]:
+        """
+        Language and character set used within the resource. A string
+        conforming to IETF BCP 47.
+
+        MANDATORY: if a language is used in the resource.
+        """
 
     @property
-    def environment_description(self) -> str:
-        """Description of the resource in the producer's processing environment, including items such as the software, the computer operating system, file name, and the dataset size."""
-        return None
+    @abstractmethod
+    def other_locale(self) -> Optional[Sequence[str]]:
+        """
+        Alternate localised language(s) and character set(s) used within
+        the resource. A string conforming to IETF BCP 47.
+        """
 
     @property
-    def supplemental_information(self) -> str:
+    @abstractmethod
+    def environment_description(self) -> Optional[str]:
+        """
+        Description of the resource in the producer's processing environment,
+        including items such as the software, the computer operating system,
+        file name, and the dataset size.
+        """
+
+    @property
+    @abstractmethod
+    def supplemental_information(self) -> Optional[str]:
         """Any other descriptive information about the resource."""
-        return None

--- a/geoapi/src/main/python/opengis/metadata/lineage.py
+++ b/geoapi/src/main/python/opengis/metadata/lineage.py
@@ -1,134 +1,256 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the lineage module.
+
+This module contains geographic metadata structures derived from the
+ISO 19115-1:2014 and ISO 19115-2:2019 international standards regarding
+the lineage of the data, that is how the data has changed and the sources
+from which it is derived.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Optional
 
+from opengis.metadata.citation import Citation, Identifier, Responsibility
+from opengis.metadata.identification import Resolution
+from opengis.metadata.maintenance import Scope
+from opengis.metadata.naming import MemberName, Record, RecordType
+from opengis.metadata.service import ParameterDirection
+from opengis.referencing.crs import ReferenceSystem
+from opengis.util.measure import Distance
 
 
 class NominalResolution(ABC):
-    """Distance between adjacent pixels."""
+    """
+    Distance between consistent parts (centre, left side, right side) of
+    adjacent pixels.
+    """
 
     @property
-    def scanning_resolution(self) -> float:
-        """Distance between adjacent pixels in the scan plane."""
-        return None
+    @abstractmethod
+    def scanning_resolution(self) -> Distance:
+        """
+        Distance between consistent parts (centre, left side, right side)
+        of adjacent pixels in the scan plane.
+        """
 
     @property
-    def ground_resolution(self) -> float:
-        """Distance between adjacent pixels in the object space."""
-        return None
+    @abstractmethod
+    def ground_resolution(self) -> Distance:
+        """
+        Distance between consistent parts (centre, left side, right side)
+        of adjacent pixels in the object space.
+        """
 
-
-
-from opengis.metadata.identification import Resolution
-from opengis.metadata.citation import Citation, Identifier, Responsibility
-from opengis.metadata.maintenance import Scope
 
 class Source(ABC):
-    """Information about the source resource used in creating the data specified by the scope."""
+    """
+    Information about the source resource used in creating the data specified
+    by the scope.
+    """
 
     @property
-    def description(self) -> str:
-        """Detailed description of the level of the source resource."""
-        return None
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """
+        Detailed description of the level of the source resource.
+
+        MANDATORY: if `scope` is `None`.
+        """
 
     @property
-    def source_spatial_resolution(self) -> Resolution:
-        """Level of detail expressed as a scale factor, a distance or an angle."""
-        return None
+    @abstractmethod
+    def source_spatial_resolution(self) -> Optional[Resolution]:
+        """
+        Level of detail expressed as a scale factor, a distance or an angle.
+        """
 
     @property
-    def source_reference_system(self):
+    @abstractmethod
+    def source_reference_system(self) -> Optional[ReferenceSystem]:
         """Spatial reference system used by the source resource."""
-        # See https://github.com/opengeospatial/geoapi/issues/57
-        return None
 
     @property
-    def source_citation(self) -> Citation:
+    @abstractmethod
+    def source_citation(self) -> Optional[Citation]:
         """Recommended reference to be used for the source resource."""
-        return None
 
     @property
-    def source_metadata(self) -> Sequence[Citation]:
+    @abstractmethod
+    def source_metadata(self) -> Optional[Sequence[Citation]]:
         """Identifier and link to source metadata."""
-        return None
 
     @property
-    def scope(self) -> Scope:
-        """Type of resource and/or extent of the source."""
-        return None
+    @abstractmethod
+    def scope(self) -> Optional[Scope]:
+        """
+        Type of resource and/or extent of the source.
+
+        MANDATORY: if `description` is `None`.
+        """
 
     @property
-    def source_step(self) -> Sequence['ProcessStep']:
+    @abstractmethod
+    def source_step(self) -> Optional[Sequence['ProcessStep']]:
         """Information about process steps in which this source was used."""
-        return None
 
     @property
-    def processed_level(self) -> Identifier:
+    @abstractmethod
+    def processed_level(self) -> Optional[Identifier]:
         """Processing level of the source data."""
-        return None
 
     @property
-    def resolution(self) -> NominalResolution:
-        """Distance between two adjacent pixels."""
-        return None
-
+    @abstractmethod
+    def resolution(self) -> Optional[NominalResolution]:
+        """
+        Distance between consistent parts (centre, left side, right side)
+        of two adjacent pixels.
+        """
 
 
 class Algorithm(ABC):
-    """Details of the methodology by which geographic information was derived from the instrument readings."""
+    """
+    Details of the methodology by which geographic information was derived
+    from the instrument readings.
+    """
 
     @property
     @abstractmethod
     def citation(self) -> Citation:
         """Information identifying the algorithm and version or date."""
-        pass
 
     @property
     @abstractmethod
     def description(self) -> str:
         """Information describing the algorithm used to generate the data."""
-        pass
 
+
+class ProcessParameter(ABC):
+    """Parameter (value or resource) used in a process."""
+
+    @property
+    @abstractmethod
+    def name(self) -> MemberName:
+        """Name/type of parameter."""
+
+    @property
+    @abstractmethod
+    def direction(self) -> ParameterDirection:
+        """
+        Indication the parameter is an input to the process, an output,
+        or both.
+        """
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """Narrative explaining the role of the parameter."""
+
+    @property
+    @abstractmethod
+    def optionality(self) -> bool:
+        """Indication the parameter is required."""
+
+    @property
+    @abstractmethod
+    def repeatability(self) -> bool:
+        """
+        Indication if more than one value of the parameter may be provided.
+        """
+
+    @property
+    @abstractmethod
+    def value_type(self) -> Optional[RecordType]:
+        """Data type of the value"""
+
+    @property
+    @abstractmethod
+    def value(self) -> Optional[Record]:
+        """Constant value."""
+
+    @property
+    @abstractmethod
+    def resource(self) -> Optional[Source]:
+        """Resource to be processed."""
 
 
 class Processing(ABC):
-    """Comprehensive information about the procedure(s), process(es) and algorithm(s) applied in the process step."""
-
-    @property
-    def algorithm(self) -> Sequence[Algorithm]:
-        return None
+    """
+    Comprehensive information about the procedure(s), process(es) and
+    algorithm(s) applied in the process step.
+    """
 
     @property
     @abstractmethod
     def identifier(self) -> Identifier:
-        """Information to identify the processing package that produced the data."""
-        pass
+        """
+        Information to identify the processing package that produced the data.
+        """
 
     @property
-    def software_reference(self) -> Sequence[Citation]:
+    @abstractmethod
+    def software_reference(self) -> Optional[Sequence[Citation]]:
         """Reference to document describing processing software."""
-        return None
 
     @property
-    def procedure_description(self) -> str:
+    @abstractmethod
+    def procedure_description(self) -> Optional[str]:
         """Additional details about the processing procedures."""
-        return None
 
     @property
-    def documentation(self) -> Sequence[Citation]:
+    @abstractmethod
+    def documentation(self) -> Optional[Sequence[Citation]]:
         """Reference to documentation describing the processing."""
-        return None
 
     @property
-    def run_time_parameters(self) -> str:
-        """Parameters to control the processing operations, entered at run time."""
-        return None
+    @abstractmethod
+    def run_time_parameters(self) -> Optional[str]:
+        """
+        Parameters to control the processing operations, entered at run time.
+        """
 
+    @property
+    @abstractmethod
+    def other_property(self) -> Optional[Record]:
+        """Instance of other property type not included in `Sensor`."""
+
+    @property
+    @abstractmethod
+    def other_property_type(self) -> Optional[RecordType]:
+        """Type of other property description."""
+
+    @property
+    @abstractmethod
+    def algorithm(self) -> Optional[Sequence[Algorithm]]:
+        """
+        Details of the methodology by which geographic information was derived
+        from the instrument readings.
+        """
+
+    @property
+    @abstractmethod
+    def parameter(self) -> Optional[ProcessParameter]:
+        """Parameter(s) used in a process"""
 
 
 class ProcessStepReport(ABC):
@@ -138,95 +260,135 @@ class ProcessStepReport(ABC):
     @abstractmethod
     def name(self) -> str:
         """Name of the processing report."""
-        pass
 
     @property
-    def description(self) -> str:
+    @abstractmethod
+    def description(self) -> Optional[str]:
         """Textual description of what occurred during the process step."""
-        return None
 
     @property
-    def file_type(self) -> str:
+    @abstractmethod
+    def file_type(self) -> Optional[str]:
         """Type of file that contains that processing report."""
-        return None
 
-
-
-from datetime import datetime
 
 class ProcessStep(ABC):
-    """Information about an event or transformation in the life of a resource including the process used to maintain the resource."""
+    """
+    Information about an event or transformation in the life of the dataset
+    including details of the algorithm and software used for processing.
+    """
 
     @property
     @abstractmethod
     def description(self) -> str:
-        """Description of the event, including related parameters or tolerances."""
-        pass
+        """
+        Description of the event, including related parameters or tolerances.
+        """
 
     @property
-    def rationale(self) -> str:
+    @abstractmethod
+    def rationale(self) -> Optional[str]:
         """Requirement or purpose for the process step."""
-        return None
 
     @property
-    def step_date_time(self) -> datetime:
+    @abstractmethod
+    def step_date_time(self) -> Optional[datetime]:
         """Date, time, range or period of process step."""
-        return None
 
     @property
-    def processor(self) -> Sequence[Responsibility]:
-        """Identification of, and means of communication with, person(s) and organisation(s) associated with the process step."""
-        return None
+    @abstractmethod
+    def processor(self) -> Optional[Sequence[Responsibility]]:
+        """
+        Identification of, and means of communication with, person(s) and
+        organisation(s) associated with the process step.
+        """
 
     @property
-    def reference(self) -> Sequence[Citation]:
+    @abstractmethod
+    def reference(self) -> Optional[Sequence[Citation]]:
         """Process step documentation."""
-        return None
 
     @property
-    def scope(self) -> Scope:
+    @abstractmethod
+    def scope(self) -> Optional[Scope]:
         """Type of resource and/or extent to which the process step applies."""
-        return None
 
     @property
-    def source(self) -> Sequence[Source]:
-        return None
+    @abstractmethod
+    def source(self) -> Optional[Sequence[Source]]:
+        """
+        Type of the resource and/or extent to which the process step applies.
+        """
 
     @property
-    def processing_information(self) -> Processing:
-        return None
+    @abstractmethod
+    def output(self) -> Optional[Sequence[Source]]:
+        """
+        Description of the product generated as a result of the process step.
+        """
 
     @property
-    def report(self) -> Sequence[ProcessStepReport]:
-        return None
+    @abstractmethod
+    def processing_information(self) -> Optional[Processing]:
+        """
+        Comprehensive information about the procedure by which the algorithm
+        was applied to derive geographic data from the raw instrument
+        measurements, such as datasets, software used, and the processing
+        environment.
+        """
 
     @property
-    def output(self) -> Sequence[Source]:
-        return None
-
+    @abstractmethod
+    def report(self) -> Optional[Sequence[ProcessStepReport]]:
+        """Report generated by the process step."""
 
 
 class Lineage(ABC):
-    """Information about the events or source data used in constructing the data specified by the scope or lack of knowledge about lineage."""
+    """
+    Information about the events or source data used in constructing the data
+    specified by the scope or lack of knowledge about lineage.
+    """
 
     @property
-    def statement(self) -> str:
-        """General explanation of the data producer's knowledge about the lineage of a resource."""
-        return None
+    @abstractmethod
+    def statement(self) -> Optional[str]:
+        """
+        General explanation of the data producer's knowledge about the lineage
+        of a resource.
+        """
 
     @property
-    def scope(self) -> Scope:
-        """Type of resource and/or extent to which the lineage information applies."""
-        return None
+    @abstractmethod
+    def scope(self) -> Optional[Scope]:
+        """
+        Type of resource and/or extent to which the lineage information
+        applies.
+        """
 
     @property
-    def additional_documentation(self) -> Sequence[Citation]:
-        return None
+    @abstractmethod
+    def additional_documentation(self) -> Optional[Sequence[Citation]]:
+        """
+        Resource. Example: A publication that describes the whole process to
+        generate this resource, e.g., a dataset.
+        """
 
     @property
-    def source(self) -> Sequence[Source]:
-        return None
+    @abstractmethod
+    def process_step(self) -> Optional[Sequence[ProcessStep]]:
+        """
+        Information about events in the life of a resource specified by the
+        scope.
+
+        MANDATORY: if `statement` and `source` are `None`.
+        """
 
     @property
-    def process_step(self) -> Sequence[ProcessStep]:
-        return None
+    @abstractmethod
+    def source(self) -> Optional[Sequence[Source]]:
+        """
+        Information about the source data used in creating the data specified
+        by the scope.
+
+        MANDATORY: if `statement` and `process_step` are `None`.
+        """

--- a/geoapi/src/main/python/opengis/metadata/maintenance.py
+++ b/geoapi/src/main/python/opengis/metadata/maintenance.py
@@ -1,151 +1,321 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the maintenance module.
+
+This module contains geographic metadata structures regarding data maintenance
+derived from the ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence, Set
+from datetime import timedelta
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import Date, Responsibility
+from opengis.metadata.extent import Extent
 
 
 class MaintenanceFrequencyCode(Enum):
-    CONTINUAL = "continual"
-    DAILY = "daily"
-    WEEKLY = "weekly"
-    FORTNIGHTLY = "fortnightly"
-    MONTHLY = "monthly"
-    QUARTERLY = "quarterly"
-    BIANNUALLY = "biannually"
-    ANNUALLY = "annually"
-    AS_NEEDED = "asNeeded"
-    IRREGULAR = "irregular"
-    NOT_PLANNED = "notPlanned"
-    UNKNOWN = "unknown"
-    PERIODIC = "periodic"
-    SEMIMONTHLY = "semimonthly"
-    BIENNIALLY = "biennially"
+    """
+    Frequency with which modifications and deletions are made to the data
+    after it is first produced
+    """
 
+    CONTINUAL = "continual"
+    """Resource is repeatedly and frequentlyupdated."""
+
+    DAILY = "daily"
+    """Resource is updated each day"""
+
+    WEEKLY = "weekly"
+    """Resource is updated on a weekly basis."""
+
+    FORTNIGHTLY = "fortnightly"
+    """Resource is updated every two weeks."""
+
+    MONTHLY = "monthly"
+    """Resource is updated each month."""
+
+    QUARTERLY = "quarterly"
+    """Resource is updatedevery three months."""
+
+    BIANNUALLY = "biannually"
+    """Resource is updated twice each year."""
+
+    ANNUALLY = "annually"
+    """Resource is updated every year."""
+
+    AS_NEEDED = "asNeeded"
+    """Resource is updated as deemed necessary."""
+
+    IRREGULAR = "irregular"
+    """Resource is updated in intervals that are uneven in duration."""
+
+    NOT_PLANNED = "notPlanned"
+    """There are no plans to update the data."""
+
+    UNKNOWN = "unknown"
+    """Frequency of maintenance for the data is not known."""
+
+    PERIODIC = "periodic"
+    """Resource is updated at regular intervals."""
+
+    SEMIMONTHLY = "semimonthly"
+    """Resource is updated twice monthly."""
+
+    BIENNIALLY = "biennially"
+    """Resource is updated every two years."""
 
 
 class ScopeCode(Enum):
-    COLLECTION_HARDWARE = "collectionHardware"
-    COLLECTION_SESSION = "collectionSession"
-    SERIES = "series"
-    DATASET = "dataset"
-    NON_GEOGRAPHIC_DATASET = "nonGeographicDataset"
-    DIMENSION_GROUP = "dimensionGroup"
-    FEATURE_TYPE = "featureType"
-    FEATURE = "feature"
-    ATTRIBUTE_TYPE = "attributeType"
-    ATTRIBUTE = "attribute"
-    PROPERTY_TYPE = "propertyType"
-    FIELD_SESSION = "fieldSession"
-    SOFTWARE = "software"
-    SERVICE = "service"
-    MODEL = "model"
-    TILE = "tile"
-    METADATA = "metadata"
-    INITIATIVE = "initiative"
-    SAMPLE = "sample"
-    DOCUMENT = "document"
-    REPOSITORY = "repository"
-    AGGREGATE = "aggregate"
-    PRODUCT = "product"
-    COLLECTION = "collection"
-    COVERAGE = "coverage"
-    APPLICATION = "application"
+    """Class of information to which the referencing entity applies."""
 
+    ATTRIBUTE = "attribute"
+    """Information applies to the attribute value."""
+
+    ATTRIBUTE_TYPE = "attributeType"
+    """Information applies to the characteristic of a feature."""
+
+    COLLECTION_HARDWARE = "collectionHardware"
+    """Information applies to the collection hardware class."""
+
+    COLLECTION_SESSION = "collectionSession"
+    """Information applies to the collection session."""
+
+    DATASET = "dataset"
+    """Information applies to the dataset."""
+
+    SERIES = "series"
+    """Information applies to the series."""
+
+    NON_GEOGRAPHIC_DATASET = "nonGeographicDataset"
+    """Information applies to the non-geographic dataset."""
+
+    DIMENSION_GROUP = "dimensionGroup"
+    """Information applies to a dimension group."""
+
+    FEATURE = "feature"
+    """Information applies to a featiure."""
+
+    FEATURE_TYPE = "featureType"
+    """Information applies to a feature type."""
+
+    PROPERTY_TYPE = "propertyType"
+    """Information applies to a property type."""
+
+    FIELD_SESSION = "fieldSession"
+    """Information applies to a field session."""
+
+    SOFTWARE = "software"
+    """Information applies to a computer program or routine."""
+
+    SERVICE = "service"
+    """
+    Information applies to a capability which a service provider entity makes
+    available to s service user entity through a set of interfaces that define
+    a behaviour, such as a use case.
+    """
+
+    MODEL = "model"
+    """
+    Information applies to a copy or imitation of an existing or hypothetical
+    object.
+    """
+
+    TILE = "tile"
+    """Information applies to a tile, a spatial subset of geographic data."""
+
+    METADATA = "metadata"
+    """Information applies to metadata."""
+
+    INITIATIVE = "initiative"
+    """Information applies to an intitiative."""
+
+    SAMPLE = "sample"
+    """Information applies to a sample."""
+
+    DOCUMENT = "document"
+    """Information applies to a document."""
+
+    REPOSITORY = "repository"
+    """Information applies to a repository."""
+
+    AGGREGATE = "aggregate"
+    """Information applies to an aggregate resource."""
+
+    PRODUCT = "product"
+    """Metadata describing an ISO 19131 data product specification."""
+
+    COLLECTION = "collection"
+    """Information applies to an unstructured set."""
+
+    COVERAGE = "coverage"
+    """Information applies to a coverage."""
+
+    APPLICATION = "application"
+    """
+    Information resource hosted on a specific set of hardware and accessible
+    over a network.
+    """
 
 
 class ScopeDescription(ABC):
     """Description of the class of information covered by the information."""
 
     @property
-    def attributes(self) -> Sequence[str]:
-        """Instances of attribute types to which the information applies."""
-        return None
+    @abstractmethod
+    def attributes(self) -> Optional[Set[str]]:
+        """
+        Instances of attribute types to which the information applies.
+
+        MANDATORY: if `features`, `feature_instances`, `attribute_instances`,
+            `dataset`, and `other` are `None`.
+        """
 
     @property
-    def features(self) -> Sequence[str]:
-        """Instances of feature types to which the information applies."""
-        return None
+    @abstractmethod
+    def features(self) -> Optional[Set[str]]:
+        """
+        Instances of feature types to which the information applies.
+
+        MANDATORY: if `attributes`, `feature_instances`, `attribute_instances`,
+            `dataset`, and `other` are `None`.
+        """
 
     @property
-    def feature_instances(self) -> Sequence[str]:
-        """Feature instances to which the information applies."""
-        return None
+    @abstractmethod
+    def feature_instances(self) -> Optional[Set[str]]:
+        """
+        Feature instances to which the information applies.
+
+        MANDATORY: if `attributes`, `features`, `attribute_instances`,
+            `dataset`, and `other` are `None`.
+        """
 
     @property
-    def attribute_instances(self) -> Sequence[str]:
-        """Attribute instances to which the information applies."""
-        return None
+    @abstractmethod
+    def attribute_instances(self) -> Optional[Set[str]]:
+        """
+        Attribute instances to which the information applies.
+
+        MANDATORY: if `attributes`, `features`, `feature_instances`,
+            `dataset`, and `other` are `None`.
+        """
 
     @property
-    def dataset(self) -> str:
-        """Dataset to which the information applies."""
-        return None
+    @abstractmethod
+    def dataset(self) -> Optional[str]:
+        """
+        Dataset to which the information applies.
+
+        MANDATORY: if `attributes`, `features`, `feature_instances`,
+            `attribute_instances`, and `other` are `None`.
+        """
 
     @property
-    def other(self) -> str:
-        """Class of information that does not fall into the other categories to which the information applies."""
-        return None
+    @abstractmethod
+    def other(self) -> Optional[str]:
+        """
+        Class of information that does not fall into the other categories to
+        which the information applies.
 
+        MANDATORY: if `attributes`, `features`, `feature_instances`,
+            `attribute_instances`, and `dataset` are `None`.
+        """
 
-
-from opengis.metadata.extent import Extent
 
 class Scope(ABC):
-    """New: information about the scope of the resource."""
+    """
+    The target resource and physical extent for which information is reported.
+    Information about the scope of the resource.
+    """
 
     @property
     @abstractmethod
     def level(self) -> ScopeCode:
         """Description of the scope."""
-        pass
 
     @property
-    def extent(self) -> Sequence[Extent]:
-        return None
+    @abstractmethod
+    def extent(self) -> Optional[Sequence[Extent]]:
+        """
+        Information about the horizontal, vertical, and temporal extent of
+        the specified resource.
+        """
 
     @property
-    def level_description(self) -> Sequence[ScopeDescription]:
-        return None
+    @abstractmethod
+    def level_description(self) -> Optional[Sequence[ScopeDescription]]:
+        """
+        Detailed information/listing of the items specified by the level.
+        """
 
-
-
-from opengis.metadata.citation import Date, Responsibility
 
 class MaintenanceInformation(ABC):
     """Information about the scope and frequency of updating."""
 
     @property
-    def maintenance_and_update_frequency(self) -> MaintenanceFrequencyCode:
-        """Frequency with which changes and additions are made to the resource after the initial resource is completed."""
-        return None
+    @abstractmethod
+    def maintenance_and_update_frequency(self) -> Optional[
+        MaintenanceFrequencyCode
+    ]:
+        """
+        Frequency with which changes and additions are made to the resource
+        after the initial resource is completed.
+
+        MANDATORY: if `user_defined_maintenance_frequency` is `None`.
+        """
 
     @property
-    def maintenance_date(self) -> Sequence[Date]:
+    @abstractmethod
+    def maintenance_date(self) -> Optional[Sequence[Date]]:
         """Date information associated with maintenance of resource."""
-        return None
 
     @property
-    def user_defined_maintenance_frequency(self):
-        """Maintenance period other than those defined."""
-        return None
+    @abstractmethod
+    def user_defined_maintenance_frequency(self) -> Optional[timedelta]:
+        """
+        Maintenance period other than those defined.
+
+        MANDATORY: if `user_defined_maintenance_frequency` is `None`.
+        """
 
     @property
-    def maintenance_scope(self) -> Sequence[Scope]:
+    @abstractmethod
+    def maintenance_scope(self) -> Optional[Sequence[Scope]]:
         """Information about the scope and extent of maintenance."""
-        return None
 
     @property
-    def maintenance_note(self) -> Sequence[str]:
-        """Information regarding specific requirements for maintaining the resource."""
-        return None
+    @abstractmethod
+    def maintenance_note(self) -> Optional[Sequence[str]]:
+        """
+        Information regarding specific requirements for maintaining the
+        resource.
+        """
 
     @property
-    def contact(self) -> Sequence[Responsibility]:
-        """Identification of, and means of communicating with, person(s) and organisation(s) with responsibility for maintaining the metadata."""
-        return None
+    @abstractmethod
+    def contact(self) -> Optional[Sequence[Responsibility]]:
+        """
+        Identification of, and means of communicating with, person(s) and
+        organisation(s) with responsibility for maintaining the metadata.
+        """

--- a/geoapi/src/main/python/opengis/metadata/naming.py
+++ b/geoapi/src/main/python/opengis/metadata/naming.py
@@ -1,12 +1,31 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2024 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the naming module.
+
+This module contains geographic metadata structures regarding naming derived
+from the ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
-
+from collections.abc import Sequence
 
 
 class NameSpace(ABC):
@@ -15,15 +34,16 @@ class NameSpace(ABC):
     @property
     @abstractmethod
     def is_global(self):
-        """Indicates whether this namespace is a "top level" namespace. Global, or top-level namespaces are not contained within another namespace. The global namespace has no parent."""
-        pass
+        """
+        Indicates whether this namespace is a "top level" namespace. Global,
+        or top-level namespaces are not contained within another namespace.
+        The global namespace has no parent.
+        """
 
     @property
     @abstractmethod
     def name(self) -> 'GenericName':
         """The identifier of this namespace."""
-        pass
-
 
 
 class GenericName(ABC):
@@ -32,81 +52,90 @@ class GenericName(ABC):
     @property
     @abstractmethod
     def depth(self) -> int:
-        """Indicates the number of levels specified by this name. For any ``LocalName``, it is always one. For a ``ScopedName`` it is some number greater than or equal to 2."""
-        pass
+        """
+        Indicates the number of levels specified by this name. For any
+        `LocalName`, it is always one. For a `ScopedName` it is some number
+        greater than or equal to 2.
+        """
 
     @property
     @abstractmethod
     def scope(self) -> NameSpace:
-        """The scope (name space) in which this name is local. All names carry an association with their scope in which they are considered local, but the scope can be the global namespace."""
-        pass
+        """
+        The scope (name space) in which this name is local. All names carry an
+        association with their scope in which they are considered local, but
+        the scope can be the global namespace.
+        """
 
     @property
     @abstractmethod
     def parsed_name(self) -> Sequence['LocalName']:
-        """The sequence of local names making this generic name. The length of this sequence is the depth. It does not include the scope."""
-        pass
-
+        """
+        The sequence of local names making this generic name. The length of
+        this sequence is the depth. It does not include the scope.
+        """
 
 
 class LocalName(GenericName):
     """
-    Identifier within a name space for a local object.
-    Local names are names which are directly accessible to and maintained by a ``NameSpace``.
-    Names are local to one and only one name space.
-    The name space within which they are local is indicated by the scope.
+    Identifier within a name space for a local object. Local names are names
+    that are directly accessible to and maintained by a `NameSpace`. Names are
+    local to one and only one name space. The name space within which they are
+    local is indicated by the scope.
     """
 
-    @property
     @abstractmethod
     def __str__(self) -> str:
         """A string representation of this local name."""
-        pass
 
     @property
+    @abstractmethod
     def depth(self) -> int:
         """The number of levels specified by this name, which is always 1 for a local name."""
         return 1
 
     @property
+    @abstractmethod
     def parsed_name(self) -> Sequence['LocalName']:
-        """The sequence of local names. Since this object is itself a locale name, the parsed name is always a singleton containing only ``self``."""
+        """
+        The sequence of local names. Since this object is itself a locale name,
+        the parsed name is always a singleton containing only `self`.
+        """
         return list(self)
 
 
-
 class ScopedName(GenericName):
-    """A composite of a ``LocalName`` (as head) for locating another name space, and a ``GenericName`` (as tail) valid in that name space."""
+    """
+    A composite of a `LocalName` (as head) for locating another name space,
+    and a `GenericName` (as tail) valid in that name space.
+    """
 
     @property
     @abstractmethod
     def head(self) -> LocalName:
-        """The first element in the sequence of parsed names. The head element must exists in the same name space as this scoped name."""
-        pass
+        """
+        The first element in the sequence of parsed names. The head element
+        must exists in the same name space as this scoped name.
+        """
 
     @property
     @abstractmethod
     def tail(self) -> GenericName:
-        """Every elements in the sequence of parsed names except for the head."""
-        pass
+        """
+        Every elements in the sequence of parsed names except for the head.
+        """
 
-    @property
     @abstractmethod
     def __str__(self) -> str:
         """A string representation of this scoped name."""
-        pass
-
 
 
 class TypeName(LocalName):
-    """A local name that references a record type."
+    """A local name that references a record type."""
 
-    @property
     @abstractmethod
     def __str__(self) -> str:
         """A string representation of this type name."""
-        pass
-
 
 
 class Type(ABC):
@@ -116,54 +145,53 @@ class Type(ABC):
     @abstractmethod
     def type_name(self) -> TypeName:
         """The name that identifies this type."""
-        pass
-
 
 
 class MemberName(LocalName):
-    """A name that references either an attribute slot in a record, an attribute, operation, or association role in an object instance or a type description in some schema."""
+    """
+    A name that references either an attribute slot in a record, an attribute,
+    operation, or association role in an object instance or a type description
+    in some schema.
+    """
 
     @property
     @abstractmethod
     def attribute_type(self) -> TypeName:
         """The type of the data associated with the member."""
-        pass
 
-    @property
     @abstractmethod
     def __str__(self) -> str:
         """A string representation of this member name."""
-        pass
-
 
 
 class RecordType(Type):
-    """The type definition of a record. A ``RecordType`` defines dynamically constructed data type."""
+    """
+    The type definition of a record. A `RecordType` defines dynamically
+    constructed data type.
+    """
 
     @property
     @abstractmethod
     def type_name(self) -> TypeName:
         """The name that identifies this record type."""
-        pass
 
     @property
     @abstractmethod
     def field_type(self):
         """The dictionary of all (name, type) pairs in this record type."""
-        pass
-
 
 
 class Record(ABC):
-    """A list of logically related fields as (name, value) pairs in a dictionary."""
+    """
+    A list of logically related fields as (name, value) pairs in a dictionary.
+    """
 
     @property
+    @abstractmethod
     def type(self) -> RecordType:
         """The type definition of this record."""
-        return None
 
     @property
     @abstractmethod
     def field(self):
         """The dictionary of all (name, value) pairs in this record."""
-        pass

--- a/geoapi/src/main/python/opengis/metadata/quality.py
+++ b/geoapi/src/main/python/opengis/metadata/quality.py
@@ -1,30 +1,117 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the quality module.
+
+
+This module contains geographic metadata structures derived from the
+ISO 19115-1:2014 international standard and data quality structures derived
+from the ISO 19157:2013, including addendum A1 (2018) international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import datetime
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import Citation, Identifier
+from opengis.metadata.content import RangeDimension
+from opengis.metadata.distribution import DataFile, Format
+from opengis.metadata.identification import BrowseGraphic
+from opengis.metadata.maintenance import Scope
+from opengis.metadata.naming import Record, RecordType, TypeName
+from opengis.metadata.representation import (
+    SpatialRepresentationTypeCode,
+    SpatialRepresentation,
+)
+from opengis.util.measure import UnitOfMeasure
 
 
 class EvaluationMethodTypeCode(Enum):
-    DIRECT_INTERNAL = "directInternal"
-    DIRECT_EXTERNAL = "directExternal"
-    INDIRECT = "indirect"
+    """Type of method for evaluating an identified data quality measure."""
 
+    # DQ_EvaluationMethodTypeCode: directInternal
+    DIRECT_INTERNAL = "001"
+    """
+    Method of evaluating the quality of a data set based on inspection
+    of items within the data set, where all data required is internal
+    to the data set being evaluated.
+    """
+
+    # DQ_EvaluationMethodTypeCode: directExternal
+    DIRECT_EXTERNAL = "002"
+    """
+    Method of evaluating the quality of a data set based on inspection
+    of items within the data set, where reference data external to the data
+    set being evaluated is required.
+    """
+
+    # DQ_EvaluationMethodTypeCode: indirect
+    INDIRECT = "003"
+    """
+    Method of evaluating the quality of a data set based on external knowledge.
+    """
 
 
 class ValueStructure(Enum):
-    BAG = "BAG"
-    SET = "SET"
-    SEQUENCE = "SEQUENCE"
-    TABLE = "TABLE"
-    MATRIX = "MATRIX"
-    COVERAGE = "COVERAGE"
+    """The way in which values are grouped together."""
 
+    # DQM_ValueStructure: bag
+    BAG = "001"
+    """
+    Finite, unordered collection of related items (objects or values).
+    """
+
+    # DQM_ValueStructure: set
+    SET = "002"
+    """
+    Unordered collection of related items (objects or values) with no
+    repetition (ISO 19107:2003).
+    """
+
+    # DQM_ValueStructure: sequence
+    SEQUENCE = "003"
+    """
+    Finite, ordered collection of related items (objects or values) that may
+    be repeated (ISO 19107:2003).
+    """
+
+    # DQM_ValueStructure: table
+    TABLE = "004"
+    """
+    An arrangement of data in which each item may be identified by means of
+    arguments or keys (ISO/IEC 2382-4:1999).
+    """
+
+    # DQM_ValueStructure: matrix
+    MATRIX = "005"
+    """Rectangular array of numbers (ISO/TS 19129:2009)."""
+
+    # DQM_ValueStructure: coverage
+    COVERAGE = "006"
+    """
+    Feature that acts as a function to return values from its range for any
+    direct position within its spatial, temporal or spatiotemporal domain
+    (ISO 19123:2005).
+    """
 
 
 class StandaloneQualityReportInformation(ABC):
@@ -34,117 +121,119 @@ class StandaloneQualityReportInformation(ABC):
     @abstractmethod
     def report_reference(self) -> Citation:
         """Reference to the associated standalone quality report."""
-        pass
 
     @property
     @abstractmethod
     def abstract(self) -> str:
         """Abstract for the associated standalone quality report."""
-        pass
 
-
-
-from opengis.metadata.maintenance import Scope
-from java.util import Date
 
 class Result(ABC):
     """Generalization of more specific result classes."""
 
     @property
+    @abstractmethod
     def result_scope(self) -> Scope:
         """Scope of the result."""
-        return None
 
     @property
-    def date_time(self) -> Date:
+    @abstractmethod
+    def date_time(self) -> datetime:
         """Date when the result was generated."""
-        return None
 
-
-
-from opengis.metadata.citation import Citation
 
 class EvaluationMethod(ABC):
     """Description of the evaluation method and procedure applied."""
 
     @property
-    def evaluation_method_type(self) -> EvaluationMethodType:
+    @abstractmethod
+    def evaluation_method_type(self) -> EvaluationMethodTypeCode:
         """Type of method used to evaluate quality of the data."""
-        return None
 
     @property
+    @abstractmethod
     def evaluation_method_description(self) -> str:
         """Description of the evaluation method."""
-        return None
 
     @property
+    @abstractmethod
     def evaluation_procedure(self) -> Citation:
         """Reference to the procedure information."""
-        return None
 
     @property
+    @abstractmethod
     def reference_doc(self) -> Sequence[Citation]:
-        """Information on documents which are referenced in developing and applying a data quality evaluation method."""
-        return None
+        """
+        Information on documents which are referenced in developing and
+        applying a data quality evaluation method.
+        """
 
     @property
-    def date_time(self) -> Sequence[Date]:
-        """Date or range of dates on which a data quality measure was applied."""
-        return None
-
+    @abstractmethod
+    def date_time(self) -> Sequence[datetime]:
+        """
+        Date or range of dates on which a data quality measure was applied.
+        """
 
 
 class MeasureReference(ABC):
     """Reference to the measure used."""
 
     @property
+    @abstractmethod
     def measure_identification(self) -> Identifier:
-        """Identifier of the measure, value uniquely identifying the measure within a namespace."""
-        return None
+        """
+        Identifier of the measure, value uniquely identifying the measure
+        within a namespace.
+        """
 
     @property
+    @abstractmethod
     def name_of_measure(self) -> Sequence[str]:
         """Name of the test applied to the data."""
-        return None
 
     @property
+    @abstractmethod
     def measure_description(self) -> str:
         """Description of the measure."""
-        return None
 
-
-
-from opengis.metadata.citation import Identifier
 
 class Element(ABC):
     """Aspect of quantitative quality information."""
 
     @property
-    def Standalone_quality_report_details(self) -> str:
-        """Clause in the standaloneQualityReport where this data quality element or any related data quality element (original results in case of derivation or aggregation) is described."""
-        return None
+    @abstractmethod
+    def standalone_quality_report_details(self) -> str:
+        """
+        Clause in the standaloneQualityReport where this data quality element
+        or any related data quality element (original results in case of
+        derivation or aggregation) is described.
+        """
 
     @property
-    def Measure(self) -> MeasureReference:
+    @abstractmethod
+    def measure(self) -> MeasureReference:
         """Reference to measure used."""
-        return None
 
-     @property
-    def Evaluation_method(self) -> EvaluationMethod:
+    @property
+    @abstractmethod
+    def evaluation_method(self) -> EvaluationMethod:
         """Evaluation information."""
-        return None
 
     @property
     @abstractmethod
     def result(self) -> Sequence[Result]:
-        """Values obtained from applying a data quality measure against a specified acceptable conformance quality level."""
-        pass
+        """
+        Values obtained from applying a data quality measure against a
+        specified acceptable conformance quality level.
+        """
 
-     @property
-    def derived_element(self) -> Sequence[Element]:
-        """In case of aggregation or derivation, indicates the original element."""
-        return None
-
+    @property
+    @abstractmethod
+    def derived_element(self) -> Sequence['Element']:
+        """
+        In case of aggregation or derivation, indicates the original element.
+        """
 
 
 class DataQuality(ABC):
@@ -154,20 +243,20 @@ class DataQuality(ABC):
     @abstractmethod
     def scope(self) -> Scope:
         """The specific data to which the data quality information applies."""
-        pass
 
     @property
+    @abstractmethod
     def report(self) -> Sequence[Element]:
-        """Quantitative quality information for the data specified by the scope."""
-        return None
+        """
+        Quantitative quality information for the data specified by the scope.
+        """
 
     @property
-    def standalone_quality_report(self) -> StandaloneQualityReportInformation:
-        return None
+    @abstractmethod
+    def standalone_quality_report(self) -> \
+            Optional[StandaloneQualityReportInformation]:
+        """Reference and abstract of the attached standalone quality report."""
 
-
-
-from opengis.metadata.identification import BrowseGraphic
 
 class Description(ABC):
     """Data quality measure description."""
@@ -176,16 +265,12 @@ class Description(ABC):
     @abstractmethod
     def text_description(self) -> str:
         """Text description."""
-        pass
 
     @property
-    def extended_Description(self) -> BrowseGraphic:
+    @abstractmethod
+    def extended_description(self) -> BrowseGraphic:
         """Illustration."""
-        return None
 
-
-
-from org.opengis.util import TypeName
 
 class SourceReference(ABC):
     """Reference to the source of the data quality measure."""
@@ -194,8 +279,6 @@ class SourceReference(ABC):
     @abstractmethod
     def citation(self) -> Citation:
         """References to the source."""
-        pass
-
 
 
 class BasicMeasure(ABC):
@@ -205,25 +288,24 @@ class BasicMeasure(ABC):
     @abstractmethod
     def name(self) -> str:
         """Name of the data quality basic measure applied to the data."""
-        pass
 
     @property
     @abstractmethod
     def definition(self) -> str:
         """Definition of the data quality basic measure."""
-        pass
 
     @property
+    @abstractmethod
     def exemple(self) -> Description:
         """Illustration of the use of a data quality measure."""
-        return None
 
     @property
     @abstractmethod
     def value_type(self) -> TypeName:
-        """Value type for the result of the basic measure (shall be one of the data types defined in ISO/TS 19103:2005)."""
-        pass
-
+        """
+        Value type for the result of the basic measure (shall be one of the
+        data types defined in ISO/TS 19103:2005).
+        """
 
 
 class Measure(ABC):
@@ -233,99 +315,107 @@ class Measure(ABC):
     @abstractmethod
     def measure_identifier(self) -> Identifier:
         """Value uniquely identifying the measure within a namespace."""
-        pass
 
     @property
     @abstractmethod
     def name(self) -> str:
         """Name of the data quality measure applied to the data."""
-        pass
 
     @property
+    @abstractmethod
     def alias(self) -> str:
-        """Another recognized name, an abbreviation or a short name for the same data quality measure."""
-        return None
+        """
+        Another recognized name, an abbreviation or a short name for the same
+        data quality measure.
+        """
 
     @property
     @abstractmethod
     def element_name(self) -> TypeName:
         """Name of the data quality element for which quality is reported."""
-        pass
 
     @property
     @abstractmethod
     def definition(self) -> str:
-        """Definition of the fundamental concept for the data quality measure."""
-        pass
+        """
+        Definition of the fundamental concept for the data quality measure.
+        """
 
     @property
     @abstractmethod
-    def description(self) -> description:
-        """Description of the data quality measure, including all formulae and/or illustrations needed to establish the result of applying the measure."""
-        pass
+    def description(self) -> Description:
+        """
+        Description of the data quality measure, including all formulae and/or
+        illustrations needed to establish the result of applying the measure.
+        """
 
     @property
     @abstractmethod
     def value_type(self) -> TypeName:
-        """Value type for reporting a data quality result (shall be one of the data types defined in ISO/19103:2005)."""
-        pass
+        """
+        Value type for reporting a data quality result (shall be one of the
+        data types defined in ISO/19103:2005).
+        """
 
     @property
+    @abstractmethod
     def value_structure(self) -> ValueStructure:
         """Structure for reporting a complex data quality result."""
-        return None
 
     @property
+    @abstractmethod
     def example(self) -> Sequence[Description]:
         """Illustration of the use of a data quality measure."""
-        return None
 
     @property
     @abstractmethod
     def basic_measure(self) -> BasicMeasure:
-        """Definition of the fundamental concept for the data quality measure."""
-        pass
+        """
+        Definition of the fundamental concept for the data quality measure.
+        """
 
     @property
+    @abstractmethod
     def source_reference(self) -> Sequence[SourceReference]:
-        """Reference to the source of an item that has been adopted from an external source."""
-        return None
+        """
+        Reference to the source of an item that has been adopted from an
+        external source.
+        """
 
     @property
+    @abstractmethod
     def parameter(self):
-        """Reference to the source of an item that has been adopted from an external source."""
-        return None
-
+        """
+        Reference to the source of an item that has been adopted from an
+        external source.
+        """
 
 
 class TemporalQuality(Element):
-    """Accuracy of the temporal attributes and temporal relationships of features."""
-
+    """
+    Accuracy of the temporal attributes and temporal relationships of features.
+    """
 
 
 class Metaquality(Element):
     """Information about the reliability of data quality results."""
 
     @property
+    @abstractmethod
     def derived_element(self) -> Sequence[Element]:
         """Derived element."""
-        return None
-
 
 
 class Confidence(Metaquality):
     """Trustworthiness of a data quality result."""
 
 
-
 class Representativity(Metaquality):
     """Trustworthiness of a data quality result."""
 
 
-
 class DataEvaluation(EvaluationMethod):
     """Data evaluation method."""
-
 
 
 class SimpleBasedInspection(DataEvaluation):
@@ -334,21 +424,23 @@ class SimpleBasedInspection(DataEvaluation):
     @property
     @abstractmethod
     def sampling_scheme(self) -> str:
-        """Information of the type of sampling scheme and description of the sampling procedure."""
-        pass
+        """
+        Information of the type of sampling scheme and description of the
+        sampling procedure.
+        """
 
     @property
     @abstractmethod
     def lot_description(self) -> str:
         """Information of how lots are defined."""
-        pass
 
     @property
     @abstractmethod
     def simple_ratio(self) -> str:
-        """Information on how many samples on average are extracted for inspection from each lot of population."""
-        pass
-
+        """
+        Information on how many samples on average are extracted for
+        inspection from each lot of population.
+        """
 
 
 class IndirectEvaluation(DataEvaluation):
@@ -357,19 +449,23 @@ class IndirectEvaluation(DataEvaluation):
     @property
     @abstractmethod
     def deductive_source(self) -> str:
-        """Information on which data are used as sources in deductive evaluation method."""
-        pass
-
+        """
+        Information on which data are used as sources in deductive evaluation
+        method.
+        """
 
 
 class Homogeneity(Metaquality):
-    """Expected or tested uniformity of the results obtained for a data quality evaluation."""
-
+    """
+    Expected or tested uniformity of the results obtained for a data quality
+    evaluation.
+    """
 
 
 class FullInspection(DataEvaluation):
-    """Test of every item in the population specified by the data quality scope."""
-
+    """
+    Test of every item in the population specified by the data quality scope.
+    """
 
 
 class DescriptiveResult(Result):
@@ -379,186 +475,218 @@ class DescriptiveResult(Result):
     @abstractmethod
     def statement(self) -> str:
         """Textual expression of the descriptive result."""
-        pass
-
 
 
 class AggregationDerivation(EvaluationMethod):
     """Aggregation or derivation method."""
 
 
-
 class PositionalAccuracy(Element):
     """Accuracy of the position of features."""
 
 
-
 class AbsoluteExternalPositionalAccuracy(PositionalAccuracy):
-    """Closeness of reported coordinate values to values accepted as or being true."""
-
+    """
+    Closeness of reported coordinate values to values accepted as or being
+    true.
+    """
 
 
 class GriddedDataPositionalAccuracy(PositionalAccuracy):
-    """Closeness of gridded data position values to values accepted as or being true."""
-
+    """
+    Closeness of gridded data position values to values accepted as or being
+    true.
+    """
 
 
 class RelativeInternalPositionalAccuracy(PositionalAccuracy):
-    """Closeness of the relative positions of features in the scope to their respective relative positions accepted as or being true."""
+    """
+    Closeness of the relative positions of features in the scope to their
+    respective relative positions accepted as or being true.
+    """
 
 
-
-class TemporalConsistency(TemporalAccuracy):
+class TemporalConsistency(TemporalQuality):
     """Correctness of ordered events or sequences, if reported."""
 
 
-
-class TemporalValidity(TemporalAccuracy):
+class TemporalValidity(TemporalQuality):
     """Validity of data specified by the scope with respect to time."""
 
 
-
-class AccuracyOfATimeMeasurement(TemporalAccuracy):
-    """Correctness of the temporal references of an item (reporting of error in time measurement)."""
-
+class AccuracyOfATimeMeasurement(TemporalQuality):
+    """
+    Correctness of the temporal references of an item (reporting of error in
+    time measurement).
+    """
 
 
 class ThematicAccuracy(Element):
-    """Accuracy of quantitative attributes and the correctness of non-quantitative attributes and of the classifications of features and their relationships."""
-
+    """
+    Accuracy of quantitative attributes and the correctness of
+    non-quantitative attributes and of the classifications of features and
+    their relationships.
+    """
 
 
 class ThematicClassificationCorrectness(ThematicAccuracy):
-    """Comparison of the classes assigned to features or their attributes to a universe of discourse."""
-
+    """
+    Comparison of the classes assigned to features or their attributes to a
+    universe of discourse.
+    """
 
 
 class QuantitativeAttributeAccuracy(ThematicAccuracy):
     """Accuracy of quantitative attributes."""
 
 
-
 class NonQuantitativeAttributeCorrectness(ThematicAccuracy):
     """Correctness of non-quantitative attributes."""
 
 
-
 class LogicalConsistency(Element):
-    """Degree of adherence to logical rules of data structure, attribution and relationships (data structure can be conceptual, logical or physical)."""
-
+    """
+    Degree of adherence to logical rules of data structure, attribution and
+    relationships (data structure can be conceptual, logical or physical).
+    """
 
 
 class ConceptualConsistency(LogicalConsistency):
     """Adherence to rules of the conceptual schema."""
 
 
-
 class DomainConsistency(LogicalConsistency):
     """Adherence of values to the value domains."""
 
 
-
 class FormatConsistency(LogicalConsistency):
-    """Degree to which data is stored in accordance with the physical structure of the dataset, as described by the scope."""
-
+    """
+    Degree to which data is stored in accordance with the physical structure
+    of the dataset, as described by the scope.
+    """
 
 
 class TopologicalConsistency(LogicalConsistency):
-    """Correctness of the explicitly encoded topological characteristics of the dataset as described by the scope."""
-
+    """
+    Correctness of the explicitly encoded topological characteristics of the
+    dataset as described by the scope.
+    """
 
 
 class Completeness(Element):
-    """Presence and absence of features, their attributes and their relationships."""
-
+    """
+    Presence and absence of features, their attributes and their relationships.
+    """
 
 
 class CompletenessCommission(Completeness):
     """Excess data present in the dataset, as described by the scope."""
 
 
-
 class CompletenessOmission(Completeness):
     """Data absent from the dataset, as described by the scope."""
 
 
-
 class ConformanceResult(Result):
-    """Information about the outcome of evaluating the obtained value (or set of values) against a specified acceptable conformance quality level."""
+    """
+    Information about the outcome of evaluating the obtained value (or set of
+    values) against a specified acceptable conformance quality level.
+    """
 
     @property
     @abstractmethod
     def specification(self) -> Citation:
-        """Citation of data product specification or user requirement against which data is being evaluated."""
-        pass
+        """
+        Citation of data product specification or user requirement against
+        which data is being evaluated.
+        """
 
     @property
     @abstractmethod
     def explanation(self) -> str:
         """Explanation of the meaning of conformance for this result."""
-        pass
 
     @property
     @abstractmethod
     def is_conform(self):
         """Indication of the conformance result where 0 = fail and 1 = pass."""
-        pass
 
-
-
-from opengis.metadata.representation import SpatialRepresentationTypeCode
-from opengis.metadata.distribution import DataFile, Format
-from opengis.metadata.content import CoverageDescription
 
 class CoverageResult(Result):
-    """Result of a data quality measure organising the measured values as a coverage."""
+    """
+    Result of a data quality measure organising the measured values as a
+    coverage.
+    """
 
     @property
     @abstractmethod
     def spatial_representation_type(self) -> SpatialRepresentationTypeCode:
         """Method used to spatially represent the coverage result."""
-        pass
 
     @property
     @abstractmethod
-    def result_file(self) -> DataFile:
-        pass
+    def result_spatial_representation(self) -> SpatialRepresentation:
+        """
+        Gives a numerical representation of the data quality measurements
+        making up the coverage result.
+        """
 
     @property
     @abstractmethod
-    def result_spatial_representation(self) -> 'SpatialRepresentation':
-        pass
+    def result_content(self) -> Optional[Sequence[RangeDimension]]:
+        """
+        Describes the content of the result coverage, when the quality
+        coverage is included in the described resource, i.e. the semantic
+        definition of the data quality measures.
+
+        MANDATORY: if `result_format` and `result_file` not provided.
+        """
 
     @property
     @abstractmethod
-    def result_content_description(self) -> CoverageDescription:
-        pass
+    def result_format(self) -> Optional[Format]:
+        """
+        Provides information about the data format of the result coverage data.
 
+        MANDATORY: if `result_content` not provided.
+        """
+
+    # Below property not defined in ISO 19157:2023
     @property
     @abstractmethod
-    def result_format(self) -> Format:
-        pass
+    def result_file(self) -> Optional[DataFile]:
+        """
+        Provides information about the data file containing the result
+        coverage data.
 
+        MANDATORY: if `result_content` not provided.
+        """
 
-
-from opengis.metadata.naming import Record, RecordType
 
 class QuantitativeResult(Result):
-    """The values or information about the value(s) (or set of values) obtained from applying a data quality measure."""
+    """
+    The values or information about the value(s) (or set of values) obtained
+    from applying a data quality measure.
+    """
 
     @property
     @abstractmethod
     def value(self) -> Sequence[Record]:
-        """Quantitative value or values, content determined by the evaluation procedure used, accordingly with the value type and valueStructure defined for the measure."""
-        pass
+        """
+        Quantitative value or values, content determined by the evaluation
+        procedure used, accordingly with the value type and valueStructure
+        defined for the measure.
+        """
 
     @property
-    def value_unit(self) -> Unit:
+    @abstractmethod
+    def value_unit(self) -> UnitOfMeasure:
         """Value unit for reporting a data quality result."""
-        return None
-
 
     @property
+    @abstractmethod
     def value_record_type(self) -> RecordType:
-        """Value type for reporting a data quality result, depends of the implementation."""
-        return None
+        """
+        Value type for reporting a data quality result, depends of the
+        implementation.
+        """

--- a/geoapi/src/main/python/opengis/metadata/representation.py
+++ b/geoapi/src/main/python/opengis/metadata/representation.py
@@ -1,107 +1,237 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the representation module.
+
+This module contains geographic metadata structures regarding representation
+derived from the ISO 19115-1:2014 and ISO 19115-2:2019 international
+standards.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
 from enum import Enum
+from typing import Optional
 
+from opengis.geometry.primitive import DirectPosition, Point
+from opengis.metadata.citation import Citation
+from opengis.metadata.maintenance import Scope
+from opengis.metadata.naming import Record
+from opengis.metadata.quality import DataQuality, Element
+from opengis.referencing.crs import ReferenceSystem
 
 
 class CellGeometryCode(Enum):
-    POINT = "point"
-    AREA = "area"
-    VOXEL = "voxel"
-    STRATUM = "stratum"
+    """Code indicating the geometry represented by the grid cell value."""
 
+    POINT = "point"
+    """Each cell represents a point."""
+
+    AREA = "area"
+    """Each cell represents an area."""
+
+    VOXEL = "voxel"
+    """
+    Each cell represents a volumetric measurement on a regular grid in
+    three dimensional space.
+    """
+
+    STRATUM = "stratum"
+    """Height range for a single point vertical profile."""
 
 
 class DimensionNameTypeCode(Enum):
-    ROW = "row"
-    COLUMN = "column"
-    VERTICAL = "vertical"
-    TRACK = "track"
-    CROSS_TRACK = "crossTrack"
-    LINE = "line"
-    SAMPLE = "sample"
-    TIME = "time"
+    """Name of the dimension."""
 
+    ROW = "row"
+    """Ordinate (y) axis."""
+
+    COLUMN = "column"
+    """Abscissa (x) axis."""
+
+    VERTICAL = "vertical"
+    """Vertical (z) axis."""
+
+    TRACK = "track"
+    """Along the direction of motion of the scan point."""
+
+    CROSS_TRACK = "crossTrack"
+    """Perpendicular to the direction of motion of the scan point."""
+
+    LINE = "line"
+    """Scan line of a sensor."""
+
+    SAMPLE = "sample"
+    """Element along a scan line."""
+
+    TIME = "time"
+    """Duration."""
 
 
 class GeometricObjectTypeCode(Enum):
+    """
+    Name of point or vector objects used to locate sero-, one-, two-, or
+    three-dimensional spatial locations in the dataset.
+    """
+
     COMPLEX = "complex"
+    """
+    Set of geometric primitives such that their boundaries can be
+    represented as a union of other primitives.
+    """
+
     COMPOSITE = "composite"
+    """Connected set of curves, solids or surfaces."""
+
     CURVE = "curve"
+    """
+    Bounded, 1-dimensional geometric primitive, representing the continuous
+    image of a line.
+    """
+
     POINT = "point"
+    """
+    Zero-dimensional geometric primitive, representing a position but not
+    having an extent.
+    """
+
     SOLID = "solid"
+    """
+    Bounded, connected 3-dimensional geometric primitive, representing the
+    continuous image of a region of space.
+    """
+
     SURFACE = "surface"
-
-
-
-class SpatialRepresentationTypeCode(Enum):
-    VECTOR = "vector"
-    GRID = "grid"
-    TEXT_TABLE = "textTable"
-    TIN = "tin"
-    STEREO_MODEL = "stereoModel"
-    VIDEO = "video"
-
-
-
-class TopologyLevelCode(Enum):
-    GEOMETRY_ONLY = "geometryOnly"
-    TOPOLOGY_1D = "topology1D"
-    PLANAR_GRAPH = "planarGraph"
-    FULL_PLANAR_GRAPH = "fullPlanarGraph"
-    SURFACE_GRAPH = "surfaceGraph"
-    FULL_SURFACE_GRAPH = "fullSurfaceGraph"
-    TOPOLOGY_3D = "topology3D"
-    FULL_TOPOLOGY_3D = "fullTopology3D"
-    ABSTRACT = "abstract"
-
-
-
-class ReferenceSystemTypeCode(Enum):
-    COMPOUND_ENGINEERING_PARAMETRIC = "compoundEngineeringParametric"
-    COMPOUND_ENGINEERING_PARAMETRIC_TEMPORAL = "compoundEngineeringParametricTemporal"
-    COMPOUND_ENGINEERING_TEMPORAL = "compoundEngineeringTemporal"
-    COMPOUND_ENGINEERING_VERTICAL = "compoundEngineeringVertical"
-    COMPOUND_ENGINEERING_VERTICAL_TEMPORAL = "compoundEngineeringVerticalTemporal"
-    COMPOUND_GEOGRAPHIC2D_PARAMETRIC = "compoundGeographic2DParametric"
-    COMPOUND_GEOGRAPHIC2D_PARAMETRIC_TEMPORAL = "compoundGeographic2DParametricTemporal"
-    COMPOUND_GEOGRAPHIC2D_TEMPORAL = "compoundGeographic2DTemporal"
-    COMPOUND_GEOGRAPHIC2D_VERTICAL = "compoundGeographic2DVertical"
-    COMPOUND_GEOGRAPHIC2D_VERTICAL_TEMPORAL = "compoundGeographic2DVerticalTemporal"
-    COMPOUND_GEOGRAPHIC3D_TEMPORAL = "compoundGeographic3DTemporal"
-    COMPOUND_PROJECTED2D_PARAMETRIC = "compoundProjected2DParametric"
-    COMPOUND_PROJECTED2D_PARAMETRIC_TEMPORAL = "compoundProjected2DParametricTemporal"
-    COMPOUND_PROJECTED_TEMPORAL = "compoundProjectedTemporal"
-    COMPOUND_PROJECTED_VERTICAL = "compoundProjectedVertical"
-    COMPOUND_PROJECTED_VERTICAL_TEMPORAL = "compoundProjectedVerticalTemporal"
-    ENGINEERING = "engineering"
-    ENGINEERING_DESIGN = "engineeringDesign"
-    ENGINEERING_IMAGE = "engineeringImage"
-    GEODETIC_GEOCENTRIC = "geodeticGeocentric"
-    GEODETIC_GEOGRAPHIC_2D = "geodeticGeographic2D"
-    GEODETIC_GEOGRAPHIC_3D = "geodeticGeographic3D"
-    GEOGRAPHIC_IDENTIFIER = "geographicIdentifier"
-    LINEAR = "linear"
-    PARAMETRIC = "parametric"
-    PROJECTED = "projected"
-    TEMPORAL = "temporal"
-    VERTICAL = "vertical"
-
+    """
+    Bounded, connected 2-dimensional geometric primitive, representing the
+    continuous image of a region of a plane.
+    """
 
 
 class PixelOrientationCode(Enum):
-    CENTER = "center"
-    LOWER_LEFT = "lowerLeft"
-    LOWER_RIGHT = "lowerRight"
-    UPPER_RIGHT = "upperRight"
-    UPPER_LEFT = "upperLeft"
+    """Point in a pixel corresponding to the Earth location of the pixel"""
 
+    CENTRE = "centre"
+    """
+    Point halfway between the lower left and the upper right of the pixel.
+    """
+
+    LOWER_LEFT = "lowerLeft"
+    """
+    The corner in the pixel closest to the origin of the SRS; if two are at
+    the same distance from the origin, the one with the smallest x-value.
+    """
+
+    LOWER_RIGHT = "lowerRight"
+    """Next corner counterclockwise from the lower left."""
+
+    UPPER_RIGHT = "upperRight"
+    """Next corner counterclockwise from the lower right."""
+
+    UPPER_LEFT = "upperLeft"
+    """Next corner counterclockwise from the upper right."""
+
+
+class SpatialRepresentationTypeCode(Enum):
+    """Method used to represent geographic information in the resource."""
+
+    VECTOR = "vector"
+    """Vector data are used to represent geographic data."""
+
+    GRID = "grid"
+    """Grid data are used to represent geographic data."""
+
+    TEXT_TABLE = "textTable"
+    """Textual or tabular data are used to represent geographic data."""
+
+    TIN = "tin"
+    """Triangulated irregular network."""
+
+    STEREO_MODEL = "stereoModel"
+    """
+    Three-dimensional view formed by the intersecting homologous rays of
+    an overlapping pair of images.
+    """
+
+    VIDEO = "video"
+    """Scene from a video recording."""
+
+
+class TopologyLevelCode(Enum):
+    """Degree of the complexity of the spatial relationships."""
+
+    GEOMETRY_ONLY = "geometryOnly"
+    """
+    Geometry objects without any additional structure which describes topology.
+    """
+
+    TOPOLOGY_1D = "topology1D"
+    """
+    1-Dimensional topological complex - commonly called “chain-node” topology.
+    """
+
+    PLANAR_GRAPH = "planarGraph"
+    """
+    1-Dimensional topological complex that is planar.
+
+    NOTE: A planar graph is a graph that can be drawn in a plane in such a way
+    that no two edges intersect except at a vertex.
+    """
+
+    FULL_PLANAR_GRAPH = "fullPlanarGraph"
+    """
+    2-Dimensional topological complex that is planar.
+
+    NOTE: A 2-dimensional topological complex is commonly called
+    “full topology” in a cartographic 2D environment.
+    """
+
+    SURFACE_GRAPH = "surfaceGraph"
+    """
+    1-Dimensional topological complex that is isomorphic to a subset of
+    a surface.
+
+    NOTE: A geometric complex is isomorphic to a topological complex if their
+    elements are in a one-to-one, dimensional-and boundary-preserving
+    correspondence to one another.
+    """
+
+    FULL_SURFACE_GRAPH = "fullSurfaceGraph"
+    """
+    2-Dimensional topological complex that is isomorphic to a subset of
+    a surface.
+    """
+
+    TOPOLOGY_3D = "topology3D"
+    """
+    3-Dimensional topological complex.
+
+    NOTE: A topological complex is a collection of topological primitives that
+    are closed under the boundary operations.
+    """
+
+    FULL_TOPOLOGY_3D = "fullTopology3D"
+    """Complete coverage of a 3D Euclidean coordinate space."""
+
+    ABSTRACT = "abstract"
+    """Topological complex without any specified geometric realisation."""
 
 
 class Dimension(ABC):
@@ -111,107 +241,117 @@ class Dimension(ABC):
     @abstractmethod
     def dimension_name(self) -> DimensionNameTypeCode:
         """Name of the axis."""
-        pass
 
     @property
     @abstractmethod
     def dimension_size(self) -> int:
         """Number of elements along the axis."""
-        pass
 
     @property
+    @abstractmethod
     def resolution(self) -> float:
         """Degree of detail in the grid dataset."""
-        return None
 
     @property
-    def dimension_title(self) -> str:
-        """Enhancement/modifier of the dimension name EX for other time dimension 'runtime' or dimensionName = 'column' dimensionTitle = 'Longitude'."""
-        return None
+    @abstractmethod
+    def dimension_title(self) -> Optional[str]:
+        """
+        Enhancement/modifier of the dimension name, e.g.,
+        for a different time dimension: dimensiont_title = 'runtime'
+        or more a more general case : dimension_name = 'column'
+        dimension_title = 'Longitude'.
+        """
 
     @property
-    def dimension_description(self) -> str:
+    @abstractmethod
+    def dimension_description(self) -> Optional[str]:
         """Description of the axis."""
-        return None
-
 
 
 class GeolocationInformation(ABC):
+    """Geolocation information with data quality."""
 
     @property
-    def quality_info(self) -> Sequence['DataQuality']:
-        return None
-
+    @abstractmethod
+    def quality_info(self) -> Optional[Sequence[DataQuality]]:
+        """
+        Provides an overall assessment of quality of geolocation information.
+        """
 
 
 class GCP(ABC):
+    """Information on a ground control point (GSP)."""
 
     @property
     @abstractmethod
-    def geographic_coordinates(self):
-        pass
+    def geographic_coordinates(self) -> DirectPosition:
+        """
+        Geographic or map position of the control point, in either two
+        or three dimensions.
+        """
 
     @property
-    def accuracy_report(self) -> Sequence['Element']:
-        return None
-
+    @abstractmethod
+    def accuracy_report(self) -> Optional[Sequence[Element]]:
+        """Accuracy of a ground control point."""
 
 
 class GCPCollection(GeolocationInformation):
-
-    @property
-    @abstractmethod
-    def gcp(self) -> Sequence[GCP]:
-        """Ground control point(s) used in the collection."""
-        pass
+    """A collection of ground control points (GCPs)."""
 
     @property
     @abstractmethod
     def collection_identification(self) -> int:
         """Identifier of the GCP collection."""
-        pass
 
     @property
     @abstractmethod
     def collection_name(self) -> str:
         """Name of the GCP collection."""
-        pass
 
     @property
     @abstractmethod
-    def coordinate_reference_system(self):
+    def coordinate_reference_system(self) -> ReferenceSystem:
         """Coordinate system in which the ground control points are defined."""
-        # See https://github.com/opengeospatial/geoapi/issues/57
-        pass
 
+    @property
+    @abstractmethod
+    def gcp(self) -> Sequence[GCP]:
+        """Ground control point(s) used in the collection."""
 
 
 class GeometricObjects(ABC):
-    """Number of objects, listed by geometric object type, used in the dataset."""
+    """
+    Number of objects, listed by geometric object type, used in the
+    resource/dataset.
+    """
 
     @property
     @abstractmethod
     def geometric_object_type(self) -> GeometricObjectTypeCode:
-        """Name of point or vector objects used to locate zero-, one-, two-, or three-dimensional spatial locations in the dataset."""
-        pass
+        """
+        Name of point or vector objects used to locate zero-, one-, two-,
+        or three-dimensional spatial locations in the resource/dataset.
+        """
 
     @property
-    def geometric_object_count(self) -> int:
-        """Total number of the point or vector object type occurring in the dataset."""
-        return None
+    @abstractmethod
+    def geometric_object_count(self) -> Optional[int]:
+        """
+        Total number of the point or vector object type occurring in the
+        resource/dataset.
 
+        Domain: > 0
+        """
 
-
-from opengis.metadata.maintenance import Scope
 
 class SpatialRepresentation(ABC):
     """Digital mechanism used to represent spatial information."""
 
     @property
-    def scope(self) -> Scope:
+    @abstractmethod
+    def scope(self) -> Optional[Scope]:
         """Level and extent of the spatial representation."""
-        return None
-
 
 
 class GridSpatialRepresentation(SpatialRepresentation):
@@ -221,124 +361,165 @@ class GridSpatialRepresentation(SpatialRepresentation):
     @abstractmethod
     def number_of_dimensions(self) -> int:
         """Number of independent spatial-temporal axes."""
-        pass
 
     @property
+    @abstractmethod
     def axis_dimension_properties(self) -> Sequence[Dimension]:
         """Information about spatial-temporal axis properties."""
-        return None
 
     @property
     @abstractmethod
     def cell_geometry(self) -> CellGeometryCode:
         """Identification of grid data as point or cell."""
-        pass
 
     @property
     @abstractmethod
-    def transformation_parameter_availability(self):
-        """Indication of whether or not parameters for transformation between image coordinates and geographic or map coordinates exist (are available)."""
-        pass
-
+    def transformation_parameter_availability(self) -> bool:
+        """
+        Indication of whether or not parameters for transformation between
+        image coordinates and geographic or map coordinates exist
+        (are available).
+        """
 
 
 class VectorSpatialRepresentation(SpatialRepresentation):
     """Information about the vector spatial objects in the resource."""
 
     @property
-    def topology_level(self) -> TopologyLevelCode:
-        """Code which identifies the degree of complexity of the spatial relationships."""
-        return None
+    @abstractmethod
+    def topology_level(self) -> Optional[TopologyLevelCode]:
+        """
+        Code which identifies the degree of complexity of the spatial
+        relationships.
+        """
 
     @property
-    def geometric_objects(self) -> Sequence[GeometricObjects]:
+    @abstractmethod
+    def geometric_objects(self) -> Optional[Sequence[GeometricObjects]]:
         """Information about the geometric objects used in the resource."""
-        return None
-
 
 
 class Georectified(GridSpatialRepresentation):
-    """Grid whose cells are regularly spaced in a geographic (i.e., lat / long) or map coordinate system defined in the Spatial Referencing System (SRS) so that any cell in the grid can be geolocated given its grid coordinate and the grid origin, cell spacing, and orientation."""
+    """
+    Grid whose cells are regularly spaced in a geographic (i.e. lat / long) or
+    map coordinate system defined in the Spatial Referencing System (SRS) so
+    that any cell in the grid can be geolocated given its grid coordinate and
+    the grid origin, cell spacing, and orientation.
+    """
 
     @property
     @abstractmethod
-    def check_point_availability(self):
-        """Indication of whether or not geographic position points are available to test the accuracy of the georeferenced grid data."""
-        pass
-
-    @property
-    def check_point_description(self) -> str:
-        """Description of geographic position points used to test the accuracy of the georeferenced grid data."""
-        return None
+    def check_point_availability(self) -> bool:
+        """
+        Indication of whether or not geographic position points are available
+        to test the accuracy of the georeferenced grid data.
+        """
 
     @property
     @abstractmethod
-    def corner_points(self):
-        """Earth location in the coordinate system defined by the Spatial Reference System and the grid coordinate of the cells at opposite ends of grid coverage along two diagonals in the grid spatial dimensions. There are four corner points in a georectified grid; at least two corner points along one diagonal are required. The first corner point corresponds to the origin of the grid."""
-        pass
+    def check_point_description(self) -> Optional[str]:
+        """
+        Description of geographic position points used to test the accuracy of
+        the georeferenced grid data.
+
+        MANDATORY: if `check_point_availability` == `True`.
+        """
 
     @property
-    def centre_point(self):
-        """Earth location in the coordinate system defined by the Spatial Reference System and the grid coordinate of the cell halfway between opposite ends of the grid in the spatial dimensions."""
-        return None
+    @abstractmethod
+    def corner_points(self) -> Optional[Sequence[Point]]:
+        """
+        Earth location in the coordinate system defined by the Spatial
+        Reference System and the grid coordinate of the cells at opposite ends
+        of grid coverage along two diagonals in the grid spatial dimensions.
+        There are four corner points in a georectified grid; at least two
+        corner points along one diagonal are required. The first corner point
+        corresponds to the origin of the grid.
+
+        NOTE: The length of the `Sequence` of `Points` should be 2 - 4
+        (i.e. 2, 3, or 4).
+        """
+
+    @property
+    @abstractmethod
+    def centre_point(self) -> Optional[Point]:
+        """
+        Earth location in the coordinate system defined by the Spatial
+        Reference System and the grid coordinate of the cell halfway between
+        opposite ends of the grid in the spatial dimensions.
+        """
 
     @property
     @abstractmethod
     def point_in_pixel(self) -> PixelOrientationCode:
-        """Point in a pixel corresponding to the Earth location of the pixel."""
-        pass
+        """
+        Point in a pixel corresponding to the Earth location of the pixel.
+        """
 
     @property
-    def transformation_dimension_description(self) -> str:
+    @abstractmethod
+    def transformation_dimension_description(self) -> Optional[str]:
         """General description of the transformation."""
-        return None
 
     @property
-    def transformation_dimension_mapping(self) -> Sequence[str]:
-        """Information about which grid axes are the spatial (map) axes."""
-        return None
+    @abstractmethod
+    def transformation_dimension_mapping(self) -> Optional[Sequence[str]]:
+        """
+        Information about which grid axes are the spatial (map) axes.
+
+        NOTE: The length of the `Sequence` of `str` should be 2. That is
+        len(list(str)) should return 2.
+        """
 
     @property
-    def check_point(self) -> Sequence[GCP]:
-        return None
+    @abstractmethod
+    def check_point(self) -> Optional[Sequence[GCP]]:
+        """
+        Geographic references used to validate georectification of the data.
+        """
 
-
-
-from opengis.metadata.naming import Record
-from opengis.metadata.citation import Citation
 
 class Georeferenceable(GridSpatialRepresentation):
-    """Grid with cells irregularly spaced in any given geographic/map projection coordinate system, whose individual cells can be geolocated using geolocation information supplied with the data but cannot be geolocated from the grid properties alone."""
+    """
+    ISO 19115-1: Grid with cells irregularly spaced in any given
+    geographic/map projection coordinate system, whose individual cells can be
+    geolocated using geolocation information supplied with the data but cannot
+    be geolocated from the grid properties alone.
+
+    ISO 19115-2: Description of information provided in metadata that allows
+    the geographic or map location of the raster points to be located.
+    """
 
     @property
     @abstractmethod
-    def control_point_availability(self):
+    def control_point_availability(self) -> bool:
         """Indication of whether or not control point(s) exists."""
-        pass
 
     @property
     @abstractmethod
-    def orientation_parameter_availability(self):
-        """Indication of whether or not orientation parameters are available."""
-        pass
+    def orientation_parameter_availability(self) -> bool:
+        """
+        Indication of whether or not orientation parameters are available.
+        """
 
     @property
-    def orientation_parameter_description(self) -> str:
+    @abstractmethod
+    def orientation_parameter_description(self) -> Optional[str]:
         """Description of parameters used to describe sensor orientation."""
-        return None
 
     @property
     @abstractmethod
     def georeferenced_parameters(self) -> Record:
         """Terms which support grid data georeferencing."""
-        pass
 
     @property
-    def parameter_citation(self) -> Sequence[Citation]:
+    @abstractmethod
+    def parameter_citation(self) -> Optional[Sequence[Citation]]:
         """Reference providing description of the parameters."""
-        return None
 
     @property
     @abstractmethod
     def geolocation_information(self) -> Sequence[GeolocationInformation]:
-        pass
+        """
+        Information that can be used to geo-locate the data.
+        """

--- a/geoapi/src/main/python/opengis/metadata/service.py
+++ b/geoapi/src/main/python/opengis/metadata/service.py
@@ -1,86 +1,112 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2018-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the service module.
+
+This module contains geographic metadata structures regarding data services
+derived from the ISO 19115-1:2014 international standard.
+"""
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
 from enum import Enum
+from typing import Optional
 
+from opengis.metadata.citation import Citation, OnlineResource
+from opengis.metadata.distribution import StandardOrderProcess
+from opengis.metadata.identification import DataIdentification, Identification
+from opengis.metadata.naming import GenericName, MemberName, ScopedName
 
 
 class CouplingType(Enum):
-    LOOSE = "loose"
-    MIXED = "mixed"
-    TIGHT = "tight"
+    """Class of information to which the referencing entity applies."""
 
+    LOOSE = "loose"
+    """
+    Service instance is loosely coupled with a data instance,
+    i.e. no `DataIdentification` class has to be described.
+    """
+
+    MIXED = "mixed"
+    """
+    Service instance is mixed coupled with a data instance,
+
+    i.e. `DataIdentification` describes the associated data
+    instance and additionally the service instance might work
+    with other external data instances.
+    """
+
+    TIGHT = "tight"
+    """
+    Service instance is tightly coupled with a data instance,
+    i.e. `DataIdentification` class MUST be described.
+    """
 
 
 class DCPList(Enum):
+    """Class of information to which the referencing entity applies."""
     XML = "XML"
-    CORBA = "CORBA"
-    JAVA = "JAVA"
-    COM = "COM"
-    SQL = "SQL"
-    SOAP = "SOAP"
-    Z3950 = "Z3950"
-    HTTP = "HTTP"
-    FTP = "FTP"
-    WEB_SERVICES = "WebServices"
+    "Extensible Markup Language"
 
+    CORBA = "CORBA"
+    """Common Object request Broker Architecture"""
+
+    JAVA = "JAVA"
+    """Object-oriented programming language"""
+
+    COM = "COM"
+    """Component Object Model"""
+
+    SQL = "SQL"
+    """Structured Query Language"""
+
+    SOAP = "SOAP"
+    """Simple Object Access Protocol"""
+
+    Z3950 = "Z3950"
+    """ISO 23950"""
+
+    HTTP = "HTTP"
+    """Hypertext Transfer Protocol"""
+
+    FTP = "FTP"
+    """File Transfer Protocol"""
+
+    WEB_SERVICES = "WebServices"
+    """Web service"""
 
 
 class ParameterDirection(Enum):
+    """
+    Identifies the parameter as an input to the process, or an output,
+    or both.
+    """
+
     IN = "in"
+    """Input to a process."""
+
     OUT = "out"
+    """Output of a process."""
+
     IN_OUT = "in/out"
-
-
-
-from opengis.metadata.citation import OnlineResource, Citation
-
-class OperationMetadata(ABC):
-    """Describes the signature of one and only one method provided by the service."""
-
-    @property
-    @abstractmethod
-    def operation_name(self) -> str:
-        """A unique identifier for this interface."""
-        pass
-
-    @property
-    @abstractmethod
-    def distributed_computing_platform(self) -> Sequence[DCPList]:
-        """Distributed computing platforms on which the operation has been implemented."""
-        pass
-
-    @property
-    def operation_description(self) -> str:
-        """Free text description of the intent of the operation and the results of the operation."""
-        return None
-
-    @property
-    def invocation_name(self) -> str:
-        """The name used to invoke this interface within the context of the DCP. The name is identical for all DCPs."""
-        return None
-
-    @property
-    @abstractmethod
-    def connect_point(self) -> Sequence[OnlineResource]:
-        """Handle for accessing the service interface."""
-        pass
-
-    @property
-    def parameter(self):
-        """The parameters that are required for this interface."""
-        return None
-
-    @property
-    def depends_on(self) -> Sequence['OperationMetadata']:
-        """List of operation that must be completed immediately before current operation is invoked."""
-        return None
-
+    """Both an input and an output."""
 
 
 class OperationChainMetadata(ABC):
@@ -90,98 +116,250 @@ class OperationChainMetadata(ABC):
     @abstractmethod
     def name(self) -> str:
         """The name, as used by the service for this chain."""
-        pass
-
-    @property
-    def description(self) -> str:
-        """A narrative explanation of the services in the chain and resulting output."""
-        return None
 
     @property
     @abstractmethod
-    def operation(self) -> Sequence[OperationMetadata]:
-        pass
+    def description(self) -> Optional[str]:
+        """
+        A narrative explanation of the services in the chain and resulting
+        output.
+        """
 
+    @property
+    @abstractmethod
+    def operation(self) -> Sequence['OperationMetadata']:
+        """(Ordered) information about the operation applied by the chain."""
 
-
-from opengis.metadata.naming import ScopedName, GenericName
-from opengis.metadata.identification import DataIdentification, Identification
 
 class CoupledResource(ABC):
-    """Links a given operationName (mandatory attribute of SV_OperationMetadata) with a data set identified by an 'identifier'."""
+    """
+    Links a given operationName (mandatory attribute of `OperationMetadata`)
+    with a dataset identified by an 'identifier'.
+    """
 
     @property
-    def scoped_name(self) -> ScopedName:
-        """Scoped identifier of the resource in the context of the given service instance. NOTE: name of the resources (i.e. dataset) as it is used by a service instance (e.g. layer name or featureTypeName)."""
-        return None
+    @abstractmethod
+    def scoped_name(self) -> Optional[ScopedName]:
+        """
+        Scoped identifier of the resource in the context of the given service
+        instance.
+
+        Links a given `operation_name` (mandatory attribute of
+        `OperationMetadata` with a resource identified by an `Identifier`.
+
+        NOTE: name of the resources (i.e. dataset) as it is used by
+        a service instance
+
+        Example: layer name or `feature_type_name`.
+        """
 
     @property
-    def resource_reference(self) -> Sequence[Citation]:
-        """Reference to the dataset on which the service operates."""
-        return None
+    @abstractmethod
+    def resource_reference(self) -> Optional[Sequence[Citation]]:
+        """
+        Reference to the dataset on which the service operates.
+
+        NOTE: For one resource either `resource` or `resource_reference`
+        should be used but not both for the same resource.
+        """
 
     @property
-    def operation(self) -> OperationMetadata:
-        return None
+    @abstractmethod
+    def resource(self) -> Optional[Sequence[DataIdentification]]:
+        """
+        The tightly coupled resource.
+
+        NOTE 1: This attribute should be implemented by reference.
+
+        NOTE 2: For one resource either `resource` or `resource_reference`
+        should be used but not both for the same resource.
+        """
 
     @property
-    def resource(self) -> Sequence[DataIdentification]:
-        return None
+    @abstractmethod
+    def operation(self) -> Optional['OperationMetadata']:
+        """
+        The service operation.
 
+        NOTE: This attribute should be implemented by reference.
+        """
 
-
-from opengis.metadata.distribution import StandardOrderProcess
 
 class ServiceIdentification(Identification):
-    """Identification of capabilities which a service provider makes available to a service user through a set of interfaces that define a behaviour - See ISO 19119 for further information."""
+    """
+    Identification of capabilities which a service provider makes available to
+    a service user through a set of interfaces that define a behaviour.
+
+    NOTE: See ISO 19119 for further information.
+    """
 
     @property
     @abstractmethod
     def service_type(self) -> GenericName:
-        """A service type name, E.G. 'discovery', 'view', 'download', 'transformation', or 'invoke'."""
-        pass
+        """
+        A service type name, e.g., 'discovery', 'view', 'download',
+        'transformation', or 'invoke'.
+        """
 
     @property
-    def service_type_version(self) -> Sequence[str]:
-        """Provide for searching based on the version of serviceType. For example, we may only be interested in OGC Catalogue V1.1 services. If version is maintained as a separate attribute, users can easily search for all services of a type regardless of the version."""
-        return None
+    @abstractmethod
+    def service_type_version(self) -> Optional[Sequence[str]]:
+        """
+        Provide for searching based on the version of serviceType.
+
+        For example, we may only be interested in OGC Catalogue V1.1 services.
+        If version is maintained as a separate attribute, users can easily
+        search for all services of a type regardless of the version.
+        """
 
     @property
-    def access_properties(self) -> StandardOrderProcess:
-        """Information about the availability of the service, including, 'fees' 'planned' 'available date and time' 'ordering instructions' 'turnaround'."""
-        return None
+    @abstractmethod
+    def access_properties(self) -> Optional[StandardOrderProcess]:
+        """
+        Information about the availability of the service, including 'fees',
+        'planned', 'available date and time', 'ordering instructions',
+        and 'turnaround'.
+        """
 
     @property
-    def coupling_type(self) -> CouplingType:
-        """Type of coupling between service and associated data (if exists)."""
-        return None
+    @abstractmethod
+    def coupling_type(self) -> Optional[CouplingType]:
+        """
+        Type of coupling between service and associated data (if exists).
+
+        MANDATORY: if `coupled_resource` is not `None`.
+        """
 
     @property
-    def coupled_resource(self) -> Sequence[CoupledResource]:
-        """Further description of the data coupling in the case of tightly coupled services."""
-        return None
+    @abstractmethod
+    def coupled_resource(self) -> Optional[Sequence[CoupledResource]]:
+        """
+        Further description of the data coupling in the case of tightly
+        coupled services.
+        """
 
     @property
-    def operated_dataset(self) -> Sequence[Citation]:
-        """Provides a reference to the dataset on which the service operates."""
-        return None
+    @abstractmethod
+    def operated_dataset(self) -> Optional[Sequence[Citation]]:
+        """
+        Provides a reference to the dataset on which the service operates.
+        """
 
     @property
-    def profile(self) -> Sequence[Citation]:
-        return None
+    @abstractmethod
+    def profile(self) -> Optional[Sequence[Citation]]:
+        """Profile to which the service adheres."""
 
     @property
-    def service_standard(self) -> Sequence[Citation]:
-        return None
+    @abstractmethod
+    def service_standard(self) -> Optional[Sequence[Citation]]:
+        """Standard to which the service adheres."""
 
     @property
-    def contains_operations(self) -> Sequence[OperationMetadata]:
-        return None
+    @abstractmethod
+    def contains_operations(self) -> Optional[Sequence['OperationMetadata']]:
+        """
+        Provides information about the operationsthat comprise the service.
+        """
 
     @property
-    def operates_on(self) -> Sequence[DataIdentification]:
-        return None
+    @abstractmethod
+    def operates_on(self) -> Optional[Sequence[DataIdentification]]:
+        """
+        Provides information about the resources on which the service operates.
+
+        NOTE: Either `operated_dataset` or `operates_on`may be used but not
+            both for the same resource.
+        """
 
     @property
-    def contains_chain(self) -> Sequence[OperationChainMetadata]:
-        return None
+    @abstractmethod
+    def contains_chain(self) -> Optional[Sequence[OperationChainMetadata]]:
+        """Provide infromation about the chain applied by the resource."""
+
+
+class Parameter(ABC):
+    """Parameter information."""
+
+    @property
+    @abstractmethod
+    def name(self) -> MemberName:
+        """The name, as used by the service, for this parameter."""
+
+    @property
+    @abstractmethod
+    def direction(self) -> ParameterDirection:
+        """
+        Indication if the parameter is an input to the service, an output,
+        or both.
+        """
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """A narrative explanation of the role of the parameter."""
+
+    @property
+    @abstractmethod
+    def optionality(self) -> bool:
+        """Indication if the parameter is required."""
+
+    @property
+    @abstractmethod
+    def repeatability(self) -> bool:
+        """
+        Indication if more than one value of the parameter may be provided.
+        """
+
+
+class OperationMetadata(ABC):
+    """
+    Describes the signature of one and only one method provided by the service.
+    """
+
+    @property
+    @abstractmethod
+    def operation_name(self) -> str:
+        """A unique identifier for this interface."""
+
+    @property
+    @abstractmethod
+    def distributed_computing_platform(self) -> Sequence[DCPList]:
+        """
+        Distributed computing platforms on which the operation has been
+        implemented.
+        """
+
+    @property
+    @abstractmethod
+    def operation_description(self) -> Optional[str]:
+        """
+        Free text description of the intent of the operation and the results
+        of the operation.
+        """
+
+    @property
+    @abstractmethod
+    def invocation_name(self) -> Optional[str]:
+        """
+        The name used to invoke this interface within the context of the DCP.
+        The name is identical for all DCPs.
+        """
+
+    @property
+    @abstractmethod
+    def connect_point(self) -> Sequence[OnlineResource]:
+        """Handle for accessing the service interface."""
+
+    @property
+    @abstractmethod
+    def parameters(self) -> Optional[Parameter]:
+        """The parameters that are required for this interface."""
+
+    @property
+    @abstractmethod
+    def depends_on(self) -> Optional[Sequence['OperationMetadata']]:
+        """
+        List of operation that must be completed immediately before current
+        operation is invoked.
+        """

--- a/geoapi/src/main/python/opengis/referencing/common.py
+++ b/geoapi/src/main/python/opengis/referencing/common.py
@@ -1,0 +1,91 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the common module.
+
+This module contains geographic metadata structures derived from the
+Common Classes package in the ISO 19111:2019 international standard.
+"""
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "David Meaux (Geomatys)"
+
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Optional
+
+from opengis.metadata.extent import Extent
+from opengis.metadata.identification import Identifier
+from opengis.metadata.naming import GenericName
+
+
+class ObjectDomain(ABC):
+    """The scope and validity of a CRS-related object."""
+
+    @property
+    @abstractmethod
+    def scope(self) -> str:
+        """
+        Description of usage, or limitations of usage, for which this object
+        is valid. If unknown, enter "not known".
+        """
+
+    @property
+    @abstractmethod
+    def domain_of_validity(self) -> Extent:
+        """The spatial and temporal extent in which this object is valid."""
+
+
+class IdentifiedObject(ABC):
+    """Identifications of a CRS-related object."""
+
+    @property
+    @abstractmethod
+    def name(self) -> Identifier:
+        """The primary name by which this object is identified."""
+
+    @property
+    @abstractmethod
+    def identifier(self) -> Optional[Sequence[Identifier]]:
+        """
+        An identifier which references elsewhere the object's defining
+        information; alternatively an identifier by which this object can be
+        referenced.
+        """
+
+    @property
+    @abstractmethod
+    def alias(self) -> Optional[Sequence[GenericName]]:
+        """An alternative name by which this object is identified."""
+
+    @property
+    @abstractmethod
+    def remarks(self) -> Optional[Sequence[str]]:
+        """
+        Comments on or information about this object, including data source
+        information.
+        """
+
+    @property
+    @abstractmethod
+    def domain(self) -> Optional[Sequence[ObjectDomain]]:
+        """The scope and validity of the object."""
+
+    @abstractmethod
+    def to_wkt(self) -> str:
+        """Returns a Well-Known Text (WKT) for this object."""

--- a/geoapi/src/main/python/opengis/referencing/coordinate.py
+++ b/geoapi/src/main/python/opengis/referencing/coordinate.py
@@ -1,0 +1,86 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the coordinates module.
+
+This module contains geographic metadata structures derived from the
+Coordinates package in the ISO 19111:2019 international standard.
+"""
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "David Meaux (Geomatys)"
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Optional
+
+from opengis.geometry.primitive import DirectPosition
+from opengis.referencing.crs import CoordinateReferenceSystem
+from opengis.util.measure import Measure
+
+
+class DataEpoch(ABC):
+    """
+    Time attribute of a coordinate set that is referenced to a dynamic CRS.
+    """
+
+    @property
+    @abstractmethod
+    def coordinate_epoch(self) -> Measure:
+        """
+        The date at which coordinates are referenced to a dynamic coordinate
+        reference system, expressed as a decimal year in the Gregorian
+        calendar.
+
+        EXAMPLE: 2017-03-25 in the Gregorian calendar is epoch 2017.23.
+        """
+
+
+class CoordinateSet(ABC):
+    """
+    Description of the coordinate tuples in a coordinate set. A single
+    coordinate tuple is treated as a special case of coordinate set containing
+    only one member.
+    """
+
+    @property
+    @abstractmethod
+    def coordinate_tuple(self) -> Sequence[DirectPosition]:
+        """Position described by a coordinate tuple."""
+
+
+class CoordinateMetadata(ABC):
+    """
+    Metadata required to reference coordinates.
+    """
+
+    @property
+    @abstractmethod
+    def coordinate_referencea_system(self) -> CoordinateReferenceSystem:
+        """
+        Identifier of the coordinate reference system to which a coordinate
+        set is referenced.
+        """
+
+    @property
+    @abstractmethod
+    def coordinate_epoch(self) -> Optional[DataEpoch]:
+        """
+        Epoch at which coordinate referenced to a dynamic CRS are valid.
+
+        MANDATORY: if the coordinate reference system is dynamic.
+        """

--- a/geoapi/src/main/python/opengis/referencing/cs.py
+++ b/geoapi/src/main/python/opengis/referencing/cs.py
@@ -1,8 +1,28 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2019-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the cs module.
+
+This module contains geographic metadata structures regarding coordinate
+systems derived from the ISO 19111 international standard.
+"""
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import abstractmethod
 from enum import Enum
@@ -12,48 +32,185 @@ from opengis.referencing.datum import IdentifiedObject
 
 class AxisDirection(Enum):
     """
-    The direction of positive increase in the coordinate value for a coordinate system axis.
-    This direction is exact in some cases, and is approximate in other cases.
+    The direction of positive increase in the coordinate value for a
+    coordinate system axis. This direction is exact in some cases, and is
+    approximate in other cases.
     """
-    COLUMN_NEGATIVE = "columnNegative"
-    COLUMN_POSITIVE = "columnPositive"
-    DISPLAY_DOWN = "displayDown"
-    DISPLAY_LEFT = "displayLeft"
-    DISPLAY_RIGHT = "displayRight"
-    DISPLAY_UP = "displayUp"
-    DOWN = "down"
-    EAST = "east"
-    EAST_NORTH_EAST = "eastNorthEast"
-    EAST_SOUTH_EAST = "eastSouthEast"
-    FUTURE = "future"
-    GEOCENTRIC_X = "geocentricX"
-    GEOCENTRIC_Y = "geocentricY"
-    GEOCENTRIC_Z = "geocentricZ"
+
     NORTH = "north"
-    NORTH_EAST = "northEast"
+    """
+    Axis positive direction is north. In a geodetic or projected CRS, north is
+    defined through the geodetic reference frame. In an engineering CRS, north
+    may be defined with respect to an engineering object rather than a
+    geographical direction.
+    """
+
     NORTH_NORTH_EAST = "northNorthEast"
-    NORTH_NORTH_WEST = "northNorthWest"
-    NORTH_WEST = "northWest"
-    PAST = "past"
-    ROW_NEGATIVE = "rowNegative"
-    ROW_POSITIVE = "rowPositive"
-    SOUTH = "south"
+    """Axis positive direction is approximately north-north-east."""
+
+    NORTH_EAST = "northEast"
+    """Axis positive direction is approximately north-east."""
+
+    EAST_NORTH_EAST = "eastNorthEast"
+    """Axis positive direction is approximately east-north-east."""
+
+    EAST = "east"
+    """Axis positive direction is ϖ/2 radians clockwise from north."""
+
+    EAST_SOUTH_EAST = "eastSouthEast"
+    """Axis positive direction is approximately east-south-east."""
+
     SOUTH_EAST = "southEast"
+    """Axis positive direction is approximately south-east."""
+
     SOUTH_SOUTH_EAST = "southSouthWest"
+    """Axis positive direction is approximately south-south-east."""
+
+    SOUTH = "south"
+    """Axis positive direction is ϖ radians clockwise from north."""
+
     SOUTH_SOUTH_WEST = "southSouthWest"
+    """Axis positive direction is approximately south-south-west."""
+
     SOUTH_WEST = "southWest"
-    UP = "up"
-    WEST = "west"
-    WEST_NORTH_WEST = "westNorthWest"
+    """Axis positive direction is approximately south-west."""
+
     WEST_SOUTH_WEST = "westSouthWest"
+    """Axis positive direction is approximately west-south-west."""
+
+    WEST = "west"
+    """Axis positive direction is 3ϖ/2 radians clockwise from north."""
+
+    WEST_NORTH_WEST = "westNorthWest"
+    """Axis positive direction is approximately west-north-west."""
+
+    NORTH_WEST = "northWest"
+    """Axis positive direction is approximately north-west."""
+
+    NORTH_NORTH_WEST = "northNorthWest"
+    """Axis positive direction is approximately north-north-west."""
+
+    UP = "up"
+    """Axis positive direction is up relative to gravity."""
+
+    DOWN = "down"
+    """Axis positive direction is down relative to gravity."""
+
+    GEOCENTRIC_X = "geocentricX"
+    """
+    Axis positive direction is in the equatorial plane from the centre of the
+    modelled Earth towards the intersection of the equator with the prime
+    meridian.
+    """
+
+    GEOCENTRIC_Y = "geocentricY"
+    """
+    Axis positive direction is in the equatorial plane from the centre of the
+    modelled Earth towards the intersection of the equator and the meridian
+    ϖ/2 radians eastwards from the prime meridian.
+    """
+
+    GEOCENTRIC_Z = "geocentricZ"
+    """
+    Axis positive direction is from the centre of the modelled Earth parallel
+    to its rotation axis and towards its north pole.
+    """
+
+    COLUMN_POSITIVE = "columnPositive"
+    """Axis positive direction is towards higher pixel column."""
+
+    COLUMN_NEGATIVE = "columnNegative"
+    """Axis positive direction is towards lower pixel column."""
+
+    ROW_POSITIVE = "rowPositive"
+    """Axis positive direction is towards higher pixel row."""
+
+    ROW_NEGATIVE = "rowNegative"
+    """Axis positive direction is towards lower pixel row."""
+
+    DISPLAY_RIGHT = "displayRight"
+    """Axis positive direction is right in display."""
+
+    DISPLAY_LEFT = "displayLeft"
+    """Axis positive direction is left in display."""
+
+    DISPLAY_UP = "displayUp"
+    """
+    Axis positive direction is towards top of approximately vertical display
+    surface.
+    """
+
+    DISPLAY_DOWN = "displayDown"
+    """
+    Axis positive direction is towards bottom of approximately vertical
+    display surface.
+    """
+
+    FORWARD = "forward"
+    """
+    Axis positive direction is forward; for an observer at the centre of the
+    object this is will be towards its front, bow or nose.
+    """
+
+    AFT = "aft"
+    """
+    Axis positive direction is aft; for an observer at the centre of the
+    object this will be towards its back, stern or tail.
+    """
+
+    PORT = "port"
+    """
+    Axis positive direction is port; for an observer at the centre of the
+    object this will be towards its left.
+    """
+
+    STARBOARD = "starboard"
+    """
+    Axis positive direction is starboard; for an observer at the centre of the
+    object this will be towards its right.
+    """
+
+    CLOCKWISE = "clockwise"
+    """Axis positive direction is clockwise from a specified direction."""
+
+    COUNTER_CLOCKWISE = "counterclockwise"
+    """
+    Axis positive direction is counter clockwise from a specified direction.
+    """
+
+    TOWARDS = "towards"
+    """Axis positive direction is towards the object."""
+
+    AWAY_FROM = "awayfrom"
+    """Axis positive direction is away from the object."""
+
+    FUTURE = "future"
+    """Temporal axis positive direction is towards the future."""
+
+    PAST = "past"
+    """Temporal axis positive direction is towards the past."""
+
+    UNSPECIFIED = "unspecified"
+    """Axis positive direction is unspecified."""
 
 
 class RangeMeaning(Enum):
     """
-    Meaning of the axis value range specified through minimum value and maximum value.
+    Meaning of the axis value range specified through minimum value and
+    maximum value.
     """
+
     EXACT = "exact"
+    """
+    Any value between and including minimumValue and maximumValue is valid.
+    """
+
     WRAPAROUND = "wraparound"
+    """
+    The axis is continuous with values wrapping around at the minimum_value
+    and maximum_value. Values with the same meaning repeat modulo the
+    difference between maximum_value and minimum_value.
+    """
 
 
 class CoordinateSystemAxis(IdentifiedObject):
@@ -66,12 +223,12 @@ class CoordinateSystemAxis(IdentifiedObject):
     def abbreviation(self) -> str:
         """
         The abbreviation used for this coordinate system axes.
-        This abbreviation is also used to identify the coordinate in a coordinate tuple.
+        This abbreviation is also used to identify the coordinate in a
+        coordinate tuple.
 
         :return: The coordinate system axis abbreviation.
         :rtype: int
         """
-        pass
 
     @property
     @abstractmethod
@@ -82,25 +239,27 @@ class CoordinateSystemAxis(IdentifiedObject):
         :return: The coordinate system axis direction.
         :rtype: AxisDirection
         """
-        pass
 
     @property
     @abstractmethod
     def unit(self):
         """
         Returns the unit of measure used for this coordinate system axis.
-        The value of a coordinate in a coordinate tuple shall be recorded using this unit of measure, whenever those
-        coordinates use a coordinate reference system that uses a coordinate system that uses this axis.
+        The value of a coordinate in a coordinate tuple shall be recorded
+        using this unit of measure, whenever those coordinates use a
+        coordinate reference system that uses a coordinate system that uses
+        this axis.
 
         :return: The coordinate system axis unit.
         """
-        pass
 
     @property
+    @abstractmethod
     def minimum_value(self) -> float:
         """
-        Returns the minimum value normally allowed for this axis, in the unit of measure for the axis.
-        If there is no minimum value, then this method returns negative infinity.
+        Returns the minimum value normally allowed for this axis, in the unit
+        of measure for the axis. If there is no minimum value, then this
+        method returns negative infinity.
 
         :return: The minimum value, or the negative infinity if none.
         :rtype: float
@@ -108,10 +267,12 @@ class CoordinateSystemAxis(IdentifiedObject):
         return float("-inf")
 
     @property
+    @abstractmethod
     def maximum_value(self) -> float:
         """
-        Returns the maximum value normally allowed for this axis, in the unit of measure for the axis.
-        If there is no maximum value, then this method returns positive infinity.
+        Returns the maximum value normally allowed for this axis, in the unit
+        of measure for the axis. If there is no maximum value, then this
+        method returns positive infinity.
 
         :return: The maximum value, or the positive infinity if none.
         :rtype: float
@@ -119,24 +280,29 @@ class CoordinateSystemAxis(IdentifiedObject):
         return float("inf")
 
     @property
+    @abstractmethod
     def range_meaning(self) -> RangeMeaning:
         """
-        Returns the meaning of axis value range specified by the minimum and maximum values. This element shall be
-        omitted when both minimum and maximum values are omitted. It may be included when minimum and/or maximum values
-        are included. If this element is omitted when minimum or maximum values are included, the meaning is unspecified
+        Returns the meaning of axis value range specified by the minimum and
+        maximum values. This element shall be omitted when both minimum and
+        maximum values are omitted. It may be included when minimum and/or
+        maximum values are included. If this element is omitted when minimum
+        or maximum values are included, the meaning is unspecified.
 
         :return: The range meaning, or null in none.
         :rtype: RangeMeaning
         """
-        return None
 
 
 class CoordinateSystem(IdentifiedObject):
     """
-    The set of coordinate system axes that spans a given coordinate space. A coordinate system (CS) is derived from a
-    set of (mathematical) rules for specifying how coordinates in a given space are to be assigned to points.
-    The coordinate values in a coordinate tuple shall be recorded in the order in which the coordinate system axes
-    associations are recorded, whenever those coordinates use a coordinate reference system that uses this coordinate system.
+    The set of coordinate system axes that spans a given coordinate space.
+    A coordinate system (CS) is derived from a set of (mathematical) rules for
+    specifying how coordinates in a given space are to be assigned to points.
+    The coordinate values in a coordinate tuple shall be recorded in the order
+    in which the coordinate system axes associations are recorded, whenever
+    those coordinates use a coordinate reference system that uses this
+    coordinate system.
     """
 
     @property
@@ -148,7 +314,6 @@ class CoordinateSystem(IdentifiedObject):
         :return: The dimension of the coordinate system.
         :rtype: int
         """
-        pass
 
     @abstractmethod
     def axis(self, dimension: int) -> CoordinateSystemAxis:
@@ -160,76 +325,86 @@ class CoordinateSystem(IdentifiedObject):
         :return: The axis at the specified dimension.
         :rtype: CoordinateSystemAxis
         """
-        pass
 
 
 class AffineCS(CoordinateSystem):
     """
-    A 2- or 3-dimensional coordinate system with straight axes that are not necessarily orthogonal.
+    A 2- or 3-dimensional coordinate system with straight axes that are not
+    necessarily orthogonal.
     """
 
 
 class CartesianCS(CoordinateSystem):
     """
-    A 2- or 3-dimensional coordinate system with orthogonal straight axes. All axes shall have the same length unit of
+    A 2- or 3-dimensional coordinate system with orthogonal straight axes. All
+    axes shall have the same length unit of
     measure.
     """
 
 
 class CylindricalCS(CoordinateSystem):
     """
-    A 3-dimensional coordinate system consisting of a PolarCS extended by a straight axis perpendicular to the plane
+    A 3-dimensional coordinate system consisting of a PolarCS extended by a
+    straight axis perpendicular to the plane
     spanned by the polar CS.
     """
 
 
 class EllipsoidalCS(CoordinateSystem):
     """
-    A 2- or 3-dimensional coordinate system in which position is specified by geodetic latitude, geodetic longitude,
+    A 2- or 3-dimensional coordinate system in which position is specified by
+    geodetic latitude, geodetic longitude,
     and (in the 3D case) ellipsoidal height.
     """
 
 
 class LinearCS(CoordinateSystem):
     """
-    A 1-dimensional coordinate system that consists of the points that lie on the single axis described.
-    The associated coordinate is the distance – with or without offset – from the origin point,
-    specified through the datum definition, to the point along the axis.
+    A 1-dimensional coordinate system that consists of the points that lie on
+    the single axis described. The associated coordinate is the distance -
+    with or without offset - from the origin point, specified through the
+    datum definition, to the point along the axis.
     """
 
 
 class ParametricCS(CoordinateSystem):
     """
-    A 1-dimensional coordinate system containing a single axis. This coordinate system uses parameter values or
-    functions to describe the position of a point.
+    A 1-dimensional coordinate system containing a single axis. This
+    coordinate system uses parameter values or functions to describe the
+    position of a point.
     """
 
 
 class PolarCS(CoordinateSystem):
     """
-    A 2-dimensional coordinate system in which position is specified by the distance from the origin and the angle
-    between the line from the origin to a point and a reference direction.
+    A 2-dimensional coordinate system in which position is specified by the
+    distance from the origin and the angle between the line from the origin to
+    a point and a reference direction.
     """
 
 
 class SphericalCS(CoordinateSystem):
     """
-    A 3-dimensional coordinate system with one distance measured from the origin and two angular coordinates.
-    Not to be confused with an EllipsoidalCS based on an ellipsoid "degenerated" into a sphere.
+    A 3-dimensional coordinate system with one distance measured from the
+    origin and two angular coordinates. Not to be confused with an
+    EllipsoidalCS based on an ellipsoid "degenerated" into a sphere.
     """
 
 
 class TimeCS(CoordinateSystem):
     """
-    A 1-dimensional coordinate system containing a single time axis. This coordinate system is used to describe the
-    temporal position of a point in the specified time units from a specified time origin.
+    A 1-dimensional coordinate system containing a single time axis. This
+    coordinate system is used to describe the temporal position of a point in
+    the specified time units from a specified time origin.
     """
 
 
 class VerticalCS(CoordinateSystem):
     """
-    A 1-dimensional coordinate system used to record the heights or depths of points. Such a coordinate system is
-    usually dependent on the Earth's gravity field, perhaps loosely as when atmospheric pressure is the basis for the
-    vertical coordinate system axis. An exact definition is deliberately not provided as the complexities of the subject
-    fall outside the scope of the ISO 19111 specification.
+    A 1-dimensional coordinate system used to record the heights or depths of
+    points. Such a coordinate system is usually dependent on the Earth's
+    gravity field, perhaps loosely as when atmospheric pressure is the basis
+    for the vertical coordinate system axis. An exact definition is
+    deliberately not provided as the complexities of the subject fall outside
+    the scope of the ISO 19111 specification.
     """

--- a/geoapi/src/main/python/opengis/referencing/datum.py
+++ b/geoapi/src/main/python/opengis/referencing/datum.py
@@ -1,121 +1,119 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2019-2023 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the datum module.
 
-from abc import ABC, abstractmethod
-from enum import Enum
+This module contains geographic metadata structures regarding datums derived
+from the ISO 19111 international standard.
+"""
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
+
+from abc import abstractmethod
 from datetime import datetime
+from enum import Enum
 
 from opengis.metadata.extent import Extent
-from opengis.metadata.citation import Identifier
-
+from opengis.referencing.common import IdentifiedObject
 
 
 class RealizationMethod(Enum):
     """
-    Specification of the method by which the vertical reference frame is realized.
+    Specification of the method by which the vertical reference frame is
+    realized.
     """
     LEVELLING = "levelling"
+    """
+    The realization is by adjustment of a levelling network fixed to one or
+    more tide gauges.
+    """
+
     GEOID = "geoid"
+    """
+    The realization is through a geoid height model or a height correction
+    model. This is applied to a specified geodetic CRS.
+    """
+
     TIDAL = "tidal"
-
-
-
-class IdentifiedObject(ABC):
-    """
-    Identification and remarks information for a reference system or CRS-related object.
-    """
-
-    @property
-    @abstractmethod
-    def name(self) -> Identifier:
-        """
-        The primary name by which this object is identified.
-
-        :return: The primary name.
-        :rtype: Identifier
-        """
-        pass
-
-    @property
-    def remarks(self) -> str:
-        """
-        Comments on or information about this object, including data source information.
-
-        :return: The remarks, or None.
-        :rtype: str
-        """
-        return None
-
-    @abstractmethod
-    def to_wkt(self) -> str:
-        """
-        Returns a Well-Known Text (WKT) for this object.
-
-        :return: The Well Know Text for this object.
-        :rtype: str
-        """
-        pass
+    """The realization is through a tidal model or by tidal predictions."""
 
 
 class Datum(IdentifiedObject):
     """
-    Specifies the relationship of a coordinate system to the earth, thus creating a coordinate reference system.
+    Specifies the relationship of a coordinate system to the earth, thus
+    creating a coordinate reference system.
     """
 
     @property
-    def anchor_point(self) -> str:
+    @abstractmethod
+    def anchor_point(self) -> str | None:
         """
-        Description, possibly including coordinates, of the point or points used to anchor the datum to the Earth.
+        Description, possibly including coordinates, of the point or points
+        used to anchor the datum to the Earth.
         """
-        return None
 
     @property
+    @abstractmethod
     def domain_of_validity(self) -> Extent:
         """
-        Information about spatial, vertical, and temporal extent. This interface has four optional attributes
-        (geographic elements, temporal elements, and vertical elements) and an element called description. At least one
-        of the four shall be used.
+        Information about spatial, vertical, and temporal extent. This
+        interface has four optional attributes (geographic elements, temporal
+        elements, and vertical elements) and an element called description.
+        At least one of the four shall be used.
         """
-        return None
 
     @property
-    def realization_epoch(self) -> datetime:
+    @abstractmethod
+    def realization_epoch(self) -> datetime | None:
         """
         The time after which this datum definition is valid.
         """
-        return None
 
     @property
+    @abstractmethod
     def scope(self) -> str:
         """
-        Description of domain of usage, or limitations of usage, for which this datum object is valid.
+        Description of domain of usage, or limitations of usage, for which
+        this datum object is valid.
         """
-        return None
 
 
 class TemporalDatum(Datum):
     """
-    A temporal datum defines the origin of a temporal coordinate reference system.
+    A temporal datum defines the origin of a temporal coordinate reference
+    system.
     """
 
     @property
     @abstractmethod
     def anchor_point(self) -> None:
         """
-        This attribute is defined in the Datum parent interface, but is not used by a temporal datum.
+        This attribute is defined in the Datum parent interface, but is not
+        used by a temporal datum.
         """
-        pass
 
     @property
     @abstractmethod
     def realization_epoch(self) -> None:
         """
-        This attribute is defined in the Datum parent interface, but is not used by a temporal datum.
+        This attribute is defined in the Datum parent interface, but is not
+        used by a temporal datum.
         """
-        pass
 
     @property
     @abstractmethod
@@ -123,7 +121,6 @@ class TemporalDatum(Datum):
         """
         The date and time origin of this temporal datum.
         """
-        pass
 
 
 class VerticalDatum(Datum):
@@ -132,40 +129,41 @@ class VerticalDatum(Datum):
     """
 
     @property
+    @abstractmethod
     def realization_method(self) -> RealizationMethod:
         """
         The type of this vertical datum.
         """
-        return None
 
 
 class Ellipsoid(IdentifiedObject):
     """
-    Geometric figure that can be used to describe the approximate shape of the earth.
+    Geometric figure that can be used to describe the approximate shape of the
+    Earth.
     """
 
     @property
+    @abstractmethod
     def axis_unit(self):
         """
         Linear unit of the semi-major and semi-minor axis values.
         """
-        return None
 
     @property
     @abstractmethod
     def semi_major_axis(self) -> float:
         """
-        Length of the semi-major axis of the ellipsoid. This is the equatorial radius in axis linear unit.
+        Length of the semi-major axis of the ellipsoid. This is the equatorial
+        radius in axis linear unit.
         """
-        pass
 
     @property
     @abstractmethod
     def semi_minor_axis(self) -> float:
         """
-        Length of the semi-minor axis of the ellipsoid. This is the polar radius in axis linear unit.
+        Length of the semi-minor axis of the ellipsoid. This is the polar
+        radius in axis linear unit.
         """
-        pass
 
     @property
     @abstractmethod
@@ -173,40 +171,41 @@ class Ellipsoid(IdentifiedObject):
         """
         Value of the inverse of the flattening constant.
         """
-        pass
 
     @property
     @abstractmethod
     def is_inf_definitive(self) -> bool:
         """
-        Indicates if the inverse flattening is definitive for this ellipsoid. Some ellipsoids use the IVF as the
-        defining value, and calculate the polar radius whenever asked. Other ellipsoids use the polar radius to
-        calculate the IVF whenever asked. This distinction can be important to avoid floating-point rounding errors.
+        Indicates if the inverse flattening is definitive for this ellipsoid.
+        Some ellipsoids use the IVF as the defining value, and calculate the
+        polar radius whenever asked. Other ellipsoids use the polar radius to
+        calculate the IVF whenever asked. This distinction can be important to
+        avoid floating-point rounding errors.
         """
-        pass
 
     @property
     @abstractmethod
     def is_sphere(self) -> bool:
         """
-        true if the ellipsoid is degenerate and is actually a sphere.
-        The sphere is completely defined by the semi-major axis, which is the radius of the sphere.
+        `True` if the ellipsoid is degenerate and is actually a sphere.
+        The sphere is completely defined by the semi-major axis, which is the
+        radius of the sphere.
         """
-        pass
 
 
 class PrimeMeridian(IdentifiedObject):
     """
-    A prime meridian defines the origin from which longitude values are determined.
+    A prime meridian defines the origin from which longitude values are
+    determined.
     """
 
     @property
     @abstractmethod
     def greenwich_longitude(self) -> float:
         """
-        Longitude of the prime meridian measured from the Greenwich meridian, positive eastward.
+        Longitude of the prime meridian measured from the Greenwich meridian,
+        positive eastward.
         """
-        pass
 
     @property
     @abstractmethod
@@ -214,13 +213,12 @@ class PrimeMeridian(IdentifiedObject):
         """
         Returns the angular unit of the Greenwich longitude.
         """
-        pass
 
 
 class GeodeticDatum(Datum):
     """
-    Defines the location and precise orientation in 3-dimensional space of a defined ellipsoid (or sphere) that
-    approximates the shape of the earth.
+    Defines the location and precise orientation in 3-dimensional space of a
+    defined ellipsoid (or sphere) that approximates the shape of the earth.
     """
 
     @property
@@ -229,7 +227,6 @@ class GeodeticDatum(Datum):
         """
         Returns the ellipsoid.
         """
-        pass
 
     @property
     @abstractmethod
@@ -237,7 +234,6 @@ class GeodeticDatum(Datum):
         """
         Returns the prime meridian.
         """
-        pass
 
 
 class EngineeringDatum(Datum):

--- a/geoapi/src/main/python/opengis/referencing/operation.py
+++ b/geoapi/src/main/python/opengis/referencing/operation.py
@@ -1,20 +1,40 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
 #
-#    GeoAPI - Programming interfaces for OGC/ISO standards
-#    Copyright © 2019-2024 Open Geospatial Consortium, Inc.
-#    http://www.geoapi.org
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
 #
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the operation module.
+
+This module contains geographic metadata structures regarding referencing
+system operations derived from the ISO 19111 international standard.
+"""
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 
-from opengis.referencing.datum import IdentifiedObject
-from opengis.referencing.crs import CoordinateReferenceSystem
-from opengis.metadata.quality import PositionalAccuracy
-from opengis.metadata.extent import Extent
-from opengis.metadata.citation import Citation
 from opengis.geometry.primitive import DirectPosition
+from opengis.metadata.citation import Citation
+from opengis.metadata.extent import Extent
+from opengis.metadata.quality import PositionalAccuracy
+from opengis.referencing.crs import CoordinateReferenceSystem
+from opengis.referencing.datum import IdentifiedObject
 
 
 # TODO :
@@ -35,7 +55,6 @@ class MathTransform(ABC):
         :return: The dimension of input points.
         :rtype: int
         """
-        pass
 
     @property
     @abstractmethod
@@ -46,7 +65,6 @@ class MathTransform(ABC):
         :return: The dimension of output points.
         :rtype: int
         """
-        pass
 
     @property
     @abstractmethod
@@ -54,79 +72,94 @@ class MathTransform(ABC):
         """
         Tests whether this transform does not move any points.
 
-        :return: True if this MathTransform is an identity transform; false otherwise.
+        :return: True if this MathTransform is an identity transform; false
+            otherwise.
         :rtype: bool
         """
-        pass
 
     @abstractmethod
     def to_wkt(self) -> str:
         """
-        Returns a Well Known Text (WKT) for this object. Well know text are defined in extended Backus Naur form.
-        This operation may fails if an object is too complex for the WKT format capability.
+        Returns a Well Known Text (WKT) for this object. Well know text are
+        defined in extended Backus Naur form. This operation may fails if an
+        object is too complex for the WKT format capability.
 
         :return: The Well Known Text (WKT) for this object.
         :rtype: str
         """
-        pass
 
     @abstractmethod
     def inverse(self):
         """
-        Creates the inverse transform of this object. This method may fail if the transform is not one to one.
+        Creates the inverse transform of this object. This method may fail if
+        the transform is not one to one.
 
         :return: The inverse transform.
         :rtype: MathTransform
         """
-        pass
 
+    @abstractmethod
     def transform(self, pt_src: DirectPosition, pt_dst: DirectPosition) -> DirectPosition:
         """
         Transforms the specified ptSrc and stores the result in ptDst.
 
         :param pt_src: the specified coordinate point to be transformed.
         :type pt_src: DirectPosition
-        :param pt_dst: the specified coordinate point that stores the result of transforming ptSrc, or null.
+        :param pt_dst: the specified coordinate point that stores the result
+            of transforming ptSrc, or null.
         :type pt_dst: DirectPosition
-        :return: the coordinate point after transforming ptSrc and storing the result in ptDst,
-                 or a newly created point if ptDst was null.
+        :return: the coordinate point after transforming ptSrc and storing the
+            result in ptDst, or a newly created point if ptDst was null.
         :rtype: DirectPosition
         """
-        pass
 
-    def transform_list(self, src_pts: np.ndarray, src_off: int, dst_pts: np.ndarray, dst_off: int, num_pts: int):
+    @abstractmethod
+    def transform_list(
+        self,
+        src_pts: np.ndarray,
+        src_off: int,
+        dst_pts: np.ndarray,
+        dst_off: int,
+        num_pts: int,
+        ):
         """
-        Transforms a list of coordinate point ordinal values. This method is provided for efficiently transforming many
-        points. The supplied array of ordinal values will contain packed ordinal values. For example, if the source
-        dimension is 3, then the ordinals will be packed in this order: (x0,y0,z0, x1,y1,z1 ...).
+        Transforms a list of coordinate point ordinal values. This method is
+        provided for efficiently transforming many points. The supplied array
+        of ordinal values will contain packed ordinal values. For example, if
+        the source dimension is 3, then the ordinals will be packed in this
+        order: (x0,y0,z0, x1,y1,z1 ...).
 
         :param src_pts: the array containing the source point coordinates.
         :type src_pts: numpy.ndarray
-        :param src_off: the offset to the first point to be transformed in the source array.
+        :param src_off: the offset to the first point to be transformed in the
+            source array.
         :type src_off: int
-        :param dst_pts: the array into which the transformed point coordinates are returned. May be the same as srcPts
+        :param dst_pts: the array into which the transformed point coordinates
+            are returned. May be the same as srcPts
         :type dst_pts: numpy.ndarray
-        :param dst_off: the offset to the location of the first transformed point that is stored in the destination
+        :param dst_off: the offset to the location of the first transformed
+            point that is stored in the destination
         :type dst_off: int
         :param num_pts: the number of point objects to be transformed.
         :type num_pts: int
         """
-        pass
 
+    @abstractmethod
     def derivative(self, point: DirectPosition) -> np.ndarray:
         """
-        Gets the derivative of this transform at a point. The derivative is the matrix of the non-translating portion
-        of the approximate affine map at the point. The matrix will have dimensions corresponding to the source and
-        target coordinate systems.
+        Gets the derivative of this transform at a point. The derivative is
+        the matrix of the non-translating portion of the approximate affine
+        map at the point. The matrix will have dimensions corresponding to the
+        source and target coordinate systems.
 
         :param point: The coordinate point where to evaluate the derivative.
-                      Null value is accepted only if the derivative is the same everywhere (e.g. with affine transforms).
-                      But most map projection will requires a non-null value.
+            Null value is accepted only if the derivative is the same
+            everywhere (e.g., with affine transforms). But most map projection
+            will requires a non-null value.
         :type point: DirectPosition
         :return: The derivative at the specified point (never null).
         :rtype: numpy.ndarray
         """
-        pass
 
 
 class MathTransform1D(MathTransform):
@@ -135,15 +168,15 @@ class MathTransform1D(MathTransform):
     """
 
     @abstractmethod
-    def inverse(self):
+    def inverse(self) -> 'MathTransform1D':
         """
         Creates the inverse transform of this object.
 
         :return: The inverse transform.
         :rtype: MathTransform1D
         """
-        pass
 
+    @abstractmethod
     def transform_value(self, value: float) -> float:
         """
         Transforms the specified value.
@@ -153,19 +186,20 @@ class MathTransform1D(MathTransform):
         :return: the transformed value.
         :rtype: float
         """
-        pass
 
-    def derivative(self, value: float) -> float:
+    @abstractmethod
+    def derivative(self, value: float) -> np.ndarray:
         """
-        Gets the derivative of this function at a value. The derivative is the 1×1 matrix of the non-translating portion
-        of the approximate affine map at the value.
+        Gets the derivative of this function at a value. The derivative is the
+        1x1 matrix of the non-translating portion of the approximate affine
+        map at the value.
 
         :param value: The value where to evaluate the derivative.
         :type value: float
-        :return: The derivative at the specified point.
-        :rtype: float
+        :return: The derivative at the specified point, as an np.ndarray with
+            only one element.
+        :rtype: np.ndarray
         """
-        pass
 
 
 class Formula:
@@ -174,6 +208,7 @@ class Formula:
     """
 
     @property
+    @abstractmethod
     def formula(self) -> str:
         """
         Formula(s) or procedure used by the operation method.
@@ -181,17 +216,18 @@ class Formula:
         :return: The formula used by the operation method, or null if none.
         :rtype: str
         """
-        return None
 
     @property
+    @abstractmethod
     def citation(self) -> Citation:
         """
-        Reference to a publication giving the formula(s) or procedure used by the coordinate operation method.
+        Reference to a publication giving the formula(s) or procedure used by
+        the coordinate operation method.
 
-        :return: Reference to a publication giving the formula, or null if none.
+        :return: Reference to a publication giving the formula, or null if
+            none.
         :rtype: Citation
         """
-        return None
 
 
 class OperationMethod(IdentifiedObject):
@@ -203,14 +239,15 @@ class OperationMethod(IdentifiedObject):
     @abstractmethod
     def formula(self) -> Formula:
         """
-        Formula(s) or procedure used by this operation method. This may be a reference to a publication.
-        Note that the operation method may not be analytic, in which case this attribute references or
+        Formula(s) or procedure used by this operation method. This may be a
+            reference to a publication.
+        Note that the operation method may not be analytic, in which case this
+            attribute references or
         contains the procedure, not an analytic formula.
 
         :return: The formula used by this method.
         :rtype: Formula
         """
-        pass
 
     @property
     @abstractmethod
@@ -221,98 +258,106 @@ class OperationMethod(IdentifiedObject):
         :return: The parameters, or an empty group if none.
         :rtype: ParameterDescriptorGroup
         """
-        pass
 
 
 class CoordinateOperation(IdentifiedObject):
     """
-    A mathematical operation on coordinates that transforms or converts coordinates to another coordinate reference
-    system.
+    A mathematical operation on coordinates that transforms or converts
+    coordinates to another coordinate reference system.
     """
 
     @property
+    @abstractmethod
     def source_crs(self) -> CoordinateReferenceSystem:
         """
-        Returns the source CRS. The source CRS is mandatory for transformations only.
-        Conversions may have a source CRS that is not specified here, but through
-        ``DerivedCRS.getBaseCRS()`` instead.
+        Returns the source CRS. The source CRS is mandatory for
+        transformations only. Conversions may have a source CRS that is not
+        specified here, but through `DerivedCRS.getBaseCRS()` instead.
 
         :return: The source CRS, or null if not available.
         :rtype: CoordinateReferenceSystem
         """
-        return None
 
     @property
+    @abstractmethod
     def target_crs(self) -> CoordinateReferenceSystem:
         """
-        Returns the target CRS. The target CRS is mandatory for transformations only.
-        Conversions may have a target CRS that is not specified here, but through
-        ``DerivedCRS`` instead.
+        Returns the target CRS. The target CRS is mandatory for
+        transformations only. Conversions may have a target CRS that is not
+        specified here, but through `DerivedCRS` instead.
 
         :return: The target CRS, or null if not available.
         :rtype: CoordinateReferenceSystem
         """
-        return None
 
     @property
-    def operation_version(self) -> str:
+    @abstractmethod
+    def operation_version(self) -> str | None:
         """
-        Version of the coordinate transformation (i.e., instantiation due to the stochastic nature of the parameters).
-        Mandatory when describing a transformation, and should not be supplied for a conversion.
+        Version of the coordinate transformation (i.e., instantiation due to
+        the stochastic nature of the parameters). Mandatory when describing a
+        transformation, and should not be supplied for a conversion.
 
         :return: The coordinate operation version, or null in none.
         :rtype: str
         """
-        return None
 
     @property
+    @abstractmethod
     def coordinate_operation_accuracy(self) -> Sequence[PositionalAccuracy]:
         """
-        Estimate(s) of the impact of this operation on point accuracy. Gives position error estimates for target
-        coordinates of this coordinate operation, assuming no errors in source coordinates.
+        Estimate(s) of the impact of this operation on point accuracy. Gives
+        position error estimates for target
+        coordinates of this coordinate operation, assuming no errors in source
+        coordinates.
 
-        :return: The position error estimates, or an empty collection if not available.
+        :return: The position error estimates, or an empty collection if not
+        available.
         :rtype: Sequence[PositionalAccuracy]
         """
-        return None
 
     @property
+    @abstractmethod
     def domain_of_validity(self) -> Extent:
         """
-        Area or region or timeframe in which this coordinate operation is valid.
+        Area or region or timeframe in which this coordinate operation is
+        valid.
 
-        :return: The coordinate operation valid domain, or null if not available.
+        :return: The coordinate operation valid domain, or null if not
+            available.
         :rtype: Extent
         """
-        return None
 
     @property
     @abstractmethod
     def scope(self) -> str:
         """
-        Description of domain of usage, or limitations of usage, for which this operation is valid.
+        Description of domain of usage, or limitations of usage, for which
+        this operation is valid.
 
         :return: A description of domain of usage.
         :rtype: str
         """
-        pass
 
     @property
+    @abstractmethod
     def math_transform(self) -> MathTransform:
         """
-        Gets the math transform. The math transform will transform positions in the source coordinate reference system
-        into positions in the target coordinate reference system. It may be null in the case of defining conversions.
+        Gets the math transform. The math transform will transform positions
+        in the source coordinate reference system into positions in the target
+        coordinate reference system. It may be null in the case of defining
+        conversions.
 
-        :return: The transform from source to target CRS, or null if not applicable.
+        :return: The transform from source to target CRS, or null if not
+            applicable.
         :rtype: MathTransform
         """
-        return None
 
 
 class SingleOperation(CoordinateOperation):
     """
-    A parameterized mathematical operation on coordinates that transforms or converts coordinates to another coordinate
-    reference system.
+    A parameterized mathematical operation on coordinates that transforms or
+    converts coordinates to another coordinate reference system.
     """
 
     @property
@@ -324,7 +369,6 @@ class SingleOperation(CoordinateOperation):
         :return: The operation method.
         :rtype: OperationMethod
         """
-        pass
 
     @property
     @abstractmethod
@@ -335,13 +379,12 @@ class SingleOperation(CoordinateOperation):
         :return: The parameters values.
         :rtype: ParameterValueGroup
         """
-        pass
 
 
 class PassThroughOperation(SingleOperation):
     """
-    A pass-through operation specifies that a subset of a coordinate tuple is subject to a specific coordinate
-    operation.
+    A pass-through operation specifies that a subset of a coordinate tuple is
+    subject to a specific coordinate operation.
     """
 
     @property
@@ -353,19 +396,18 @@ class PassThroughOperation(SingleOperation):
         :return: The operation to apply on the subset of a coordinate tuple.
         :rtype: SingleOperation
         """
-        pass
 
     @property
     @abstractmethod
     def modified_coordinates(self) -> Sequence[int]:
         """
-        Ordered sequence of positive integers defining the positions in a coordinate tuple of the coordinates affected
-        by this pass-through operation.
+        Ordered sequence of positive integers defining the positions in a
+        coordinate tuple of the coordinates affected by this pass-through
+        operation.
 
         :return: The modified coordinates.
         :rtype: Sequence[int]
         """
-        pass
 
 
 class Transformation(SingleOperation):
@@ -382,7 +424,6 @@ class Transformation(SingleOperation):
         :return: The source CRS (never null).
         :rtype: CoordinateReferenceSystem
         """
-        pass
 
     @property
     @abstractmethod
@@ -393,19 +434,18 @@ class Transformation(SingleOperation):
         :return: The target CRS (never null)
         :rtype: CoordinateReferenceSystem
         """
-        pass
 
     @property
     @abstractmethod
     def operation_version(self) -> str:
         """
-        Version of the coordinate transformation (i.e., instantiation due to the stochastic nature of the parameters).
-        This attribute is mandatory in a Transformation.
+        Version of the coordinate transformation (i.e., instantiation due to
+        the stochastic nature of the parameters). This attribute is mandatory
+        in a Transformation.
 
         :return: The coordinate operation version.
         :rtype: str
         """
-        pass
 
 
 class Conversion(SingleOperation):
@@ -414,31 +454,32 @@ class Conversion(SingleOperation):
     """
 
     @property
+    @abstractmethod()
     def source_crs(self) -> CoordinateReferenceSystem:
         """
-        Returns the source CRS. Conversions may have a source CRS that is not specified here, but through
-        ``DerivedCRS.getBaseCRS()`` instead.
+        Returns the source CRS. Conversions may have a source CRS that is not
+        specified here, but through `DerivedCRS.getBaseCRS()` instead.
 
         :return: The source CRS, or null if not available.
         :rtype: CoordinateReferenceSystem
         """
-        return None
 
     @property
+    @abstractmethod()
     def target_crs(self) -> CoordinateReferenceSystem:
         """
-        Returns the target CRS. Conversions may have a target CRS that is not specified here, but through
-        ``DerivedCRS`` instead.
+        Returns the target CRS. Conversions may have a target CRS that is not
+        specified here, but through `DerivedCRS` instead.
 
         :return: The target CRS, or null if not available.
         :rtype: CoordinateReferenceSystem
         """
-        return None
 
     @property
     @abstractmethod
     def operation_version(self) -> None:
         """
-        This attribute is declared in ``CoordinateOperation`` but is not used in a conversion.
+        This attribute is declared in `CoordinateOperation` but is not used in
+        a conversion.
         """
-        pass
+        return None

--- a/geoapi/src/main/python/opengis/util/__init__.py
+++ b/geoapi/src/main/python/opengis/util/__init__.py
@@ -15,11 +15,11 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 # ===-----------------------------------------------------------------------===
-"""This is the referencing subpackage.
+"""This is the util subpackage.
 
-This subpackage contains spatial referencing data structures derived from
-the ISO 19111 international standard.
+This subpackage contains types defined in the ISO 19103:2015 specification
+for which no equivalence is already present in the Python standard library.
 """
 
-__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
-    "Martin Desruisseaux(Geomatys), David Meaux (Geomatys)"
+__author__ = "OGC Topic 20 (for abstract model and documentation), " +\
+    "David Meaux (Geomatys)"

--- a/geoapi/src/main/python/opengis/util/measure.py
+++ b/geoapi/src/main/python/opengis/util/measure.py
@@ -1,0 +1,431 @@
+# ===-----------------------------------------------------------------------===
+#    GeoAPI - Python interfaces (abstractions) for OGC/ISO standards
+#    Copyright © 2013-2024 Open Geospatial Consortium, Inc.
+#    http: //www.geoapi.org
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http: //www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# ===-----------------------------------------------------------------------===
+"""This is the measure module.
+
+This module contains measure types defined in the ISO 19103:2015
+specification for which no equivalence is already present in the Python
+standard library.
+"""
+
+__author__ = "OGC Topic 20 (for abstract model and documentation), " +\
+    "David Meaux (Geomatys)"
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Optional
+
+from opengis.geometry.primitive import Vector
+
+
+class StandardUnits(Enum):
+    """
+    Standard units are the base and named derived units that form part of the
+    International System of Units (SI), plus units which are based on SI units
+    and are required for the other measures, for example metres per second.
+    """
+    METRE = "metre"
+    SECOND = "second"
+    RADIAN = "radian"
+    SQUARE_METRE = "squareMetre"
+    CUBIC_METRE = "cubicMetre"
+    METER_PR_SECOND = "metrePrSecond"
+    METRE_PR_METRE = "metrePrMetre"
+    METRE_PR_SECOND_PR_SECOND = "metrePrSecondPrSecond"
+    RADIAN_PR_SECOND = "radianPrSecond"
+    RADIAN_PR_SECOND_PR_SECOND = "radianPrSecondPrSecond"
+    KILOGRAM = "kilomgram"
+
+
+class UnitsList(Enum):
+    """
+    This code list contains other units which are not part of SI, but are
+    in common use in some parts of the world.
+    """
+    METRE = "metre"
+    SECOND = "second"
+    RADIAN = "radian"
+    SQUARE_METRE = "squareMetre"
+    CUBIC_METRE = "cubicMetre"
+    METER_PR_SECOND = "metrePrSecond"
+    METRE_PR_METRE = "metrePrMetre"
+    METRE_PR_SECOND_PR_SECOND = "metrePrSecondPrSecond"
+    RADIAN_PR_SECOND = "radianPrSecond"
+    RADIAN_PR_SECOND_PR_SECOND = "radianPrSecondPrSecond"
+    KILOGRAM = "kilomgram"
+    FOOT = "foot"
+    SQUARE_FOOT = "squareFoot"
+    CUBIC_YARD = "cubicYard"
+
+
+class SubUnitsPerUnit(ABC):
+    """Sub units per unit."""
+
+    @property
+    @abstractmethod
+    def factor(self) -> float:
+        """The number of sub units per unit."""
+
+
+class UnitOfMeasure(ABC):
+    """
+    A UnitOfMeasure is a quantity adopted as a standard of measurement
+    for other quantities of the same kind.
+    """
+
+    @property
+    @abstractmethod
+    def uom_identifier(self) -> str:
+        """
+        A string used to identify the unit of measure.
+
+        EXAMPLES: foot, metre, radian, degree, inch, minute,
+        kilometres per hour
+        """
+
+    @property
+    @abstractmethod
+    def subunit(self) -> Optional[SubUnitsPerUnit]:
+        """The sub units per unit"""
+
+
+class UomArea(UnitOfMeasure):
+    """
+    UomArea is any of the reference quantities used to express the value of
+    area. Common units include square length units, such as square metres and
+    square feet. Other common unit include acres (in the US) and hectares.
+    """
+
+
+class UomLength(UnitOfMeasure):
+    """
+    UomLength is any of the reference quantities used to express the value of
+    the length, distance between two entities. Examples are the English System
+    of feet and inches or the metric system of millimetres, centimetres and
+    metres, also the System International (SI) System of Units.
+    """
+
+
+class UomAngle(UnitOfMeasure):
+    """
+    UomAngle is any of the reference quantities used to express the value of
+    angles. In the US, the sexagesimal system of degrees, minutes and seconds
+    is frequently used. The radian measurement system is also used. In other
+    parts of the world the grad angle, gon, measuring system is used.
+    """
+
+
+class UomAcceleration(UnitOfMeasure):
+    """
+    UomAcceleration provides both the unit of measure of the velocity and of
+    the time, for example metres per second, per second.
+    """
+
+
+class UomAngularAcceleration(UnitOfMeasure):
+    """
+    UomAngularAcceleration provides both the unit of measure of the angular
+    velocity and of the time, for example degrees per second, per second.
+    """
+
+
+class UomAngularSpeed(UnitOfMeasure):
+    """
+    UomAngularSpeed provides both the unit of measure of the angle and of the
+    time, for example degrees per second.
+    """
+
+
+class UomSpeed(UnitOfMeasure):
+    """
+    UomSpeed provides both the unit of measure of the distance and of the
+    time, for example kilometres per hour, or metres per second.
+    """
+
+
+class UomCurrency(UnitOfMeasure):
+    """
+    UomCurrency indicates the specific currency, such as one listed
+    in ISO 4217.
+    """
+
+
+class UomVolume(UnitOfMeasure):
+    """
+    UomVolume is any of the reference quantities used to express the value
+    of volume.
+    """
+
+
+class UomTime(UnitOfMeasure):
+    """
+    UomTime is any of the reference quantities used to express the value of or
+    reckoning the passage of time and/or date, (e.g. seconds, minutes,
+    days, months).
+    """
+
+
+class UomScale(UnitOfMeasure):
+    """
+    UomScale is any of the reference quantities used to express the value of
+    scale, or the ratio between quantities with the same unit. Scale factors
+    are often unitless.
+    """
+
+
+class UomWeight(UnitOfMeasure):
+    """
+    UomWeight is any of the reference quantities used to express force,
+    such as newton.
+    """
+
+
+class UomVelocity(UnitOfMeasure):
+    """
+    UomVelocity is any of the reference quantities used to express the value
+    of velocity.
+    """
+
+
+class UomAngularVelocity(UnitOfMeasure):
+    """
+    UomAngularVelocity is any of the reference quantities used to express
+    the value of angular velocity. It must include an indication of which
+    direction is considered positive.
+    """
+
+
+class Measure(ABC):
+    """
+    A Measure is the result from performing the act or process of
+    ascertaining the value of a characteristic of some entity.
+    """
+
+    @property
+    @abstractmethod
+    def value(self) -> float:
+        """The value of the measure."""
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UnitOfMeasure:
+        """The units of the measure."""
+
+
+class Length(Measure):
+    """
+    Length is the measure of distance as an integral, for example the length
+    of curve, the perimeter of a polygon as the length of the boundary.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomLength:
+        """The units of the length."""
+
+
+class Distance(Length):
+    """
+    Distance is used as a type for returning the separation between two points.
+    """
+
+
+class Speed(Measure):
+    """
+    Speed is the rate at which someone or something moves, generally expressed
+    as distance over time. It is distinct from velocity in that speed can be
+    measured along a curve.
+    """
+
+    @property
+    @abstractmethod
+    def time(self) -> UomTime:
+        "The units of measure for the time."
+
+    @property
+    @abstractmethod
+    def distance(self) -> UomLength:
+        "The units of measure for the distance."
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomSpeed:
+        """The units of the speed."""
+
+
+class Angle(Measure):
+    """
+    Angle is the amount of rotation needed to bring one line or plane into
+    coincidence with another, generally measured in radians or degrees.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomAngle:
+        """The units of the angle."""
+
+
+class Scale(Measure):
+    """Scale is the ratio of one quantity to another, often unitless."""
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomScale:
+        """The units of the length."""
+
+    @property
+    @abstractmethod
+    def source_units(self) -> UomLength:
+        """The units of the source measure."""
+
+    @property
+    @abstractmethod
+    def target_units(self) -> UomLength:
+        """The units of the target measure."""
+
+
+class TimeMeasure(Measure):
+    """
+    TimeMeasure is the designation of an instant on a selected time scale,
+    astronomical or atomic. It is used in the sense of time of day.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomTime:
+        """The units of the time."""
+
+
+class Area(Measure):
+    """
+    Area is the measure of the physical extent of any 2-D geometric object.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomArea:
+        """The units of the area."""
+
+
+class Volume(Measure):
+    """
+    Volume is the measure of the physical space of any 3-D geometric object.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomVolume:
+        """The units of the volume."""
+
+
+class Currency(Measure):
+    """
+    Currency is a system of money in general use in a particular country
+    or countries.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomCurrency:
+        """The units of the currency."""
+
+
+class Weight(Measure):
+    """
+    Weight is the force exerted on the mass of a body by a gravitational field.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomWeight:
+        """The units of the weight."""
+
+
+class AngularSpeed(Measure):
+    """
+    AngularSpeed (often known as angular velocity) is the magnitude of the
+    rate of change of angular position of a rotating body. Angular speed
+    is always positive.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomAngularSpeed:
+        """The units of the angular speed."""
+
+
+class DirectedMeasure(ABC):
+    """
+    A DirectedMeasure is the result of ascertaining the value of
+    a characteristic of some entity where direction is an essential aspect
+    of the characteristic.
+    """
+
+    @property
+    @abstractmethod
+    def value(self) -> Vector:
+        """
+        The magnitude and direction of the directed measure.
+        """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UnitOfMeasure:
+        """The units of the directed measure."""
+
+
+class Velocity(DirectedMeasure):
+    """
+    Velocity is the instantaneous rate of change of position with time.
+    It is usually calculated using the simple formula, the change in position
+    during a given time interval.
+    """
+
+
+class AngularVelocity(DirectedMeasure):
+    """
+    AngularVelocity is the instantaneous rate of change of angular
+    displacement with time.
+    """
+
+    @property
+    @abstractmethod
+    def unit_of_measure(self) -> UomSpeed:
+        """The units of the speed."""
+
+    @property
+    @abstractmethod
+    def time(self) -> UomTime:
+        """The units of the time."""
+
+    @property
+    @abstractmethod
+    def angle(self) -> UomAngle:
+        """The units of the angle."""
+
+
+class Acceleration(DirectedMeasure):
+    """
+    Acceleration is the rate of change of velocity per unit of time.
+    """
+
+
+class AngularAcceleration(DirectedMeasure):
+    """
+    AngularAcceleration is the rate of change of angular velocity per unit
+    of time.
+    """

--- a/geoapi/src/main/python/python-todo.md
+++ b/geoapi/src/main/python/python-todo.md
@@ -1,0 +1,150 @@
+# Python "To Do" List
+## Specifications
+### ISO Standards
+- [ ] 19103
+- [ ] 19107
+- [ ] 19108 (?)
+- [ ] 19109 (?)
+- [ ] 19110 (?)
+- [ ] 19111
+- [ ] 19112 (?)
+- [x] 19115-1:2014
+    - [x] 19115-1 A1 (2018)
+    - [x] 19115-1 A2 (2020)
+    - metadata.lineage
+        - ProcessStep
+- [x] 19115-2:2018
+    - [x] 19115-2 A1 (2022)
+    - modules
+        - metadata.aquisition
+        - metadata.lineage
+        - metadata.representation
+        - metadata.content
+        - CodeLists
+- [ ] 19115-3
+- [ ] 19157:2013 / 19157:2023 (?)
+### OGC Standards
+- [ ] 01009 (?)
+- [ ] Filter (?)
+- [ ] Moving Feature (?)
+
+## Library of Enums and Abstract Classes
+- [x] ISO 19103:2015 mapping to python types
+    - [x] Bit --> unimplemented
+    - [x] Digit --> unimplemented
+    - [x] Sign --> unimplemented
+- [x] Conform to PEP8; reflect ISO inheritance patterns
+- [x] Abstract method return types
+    - [x] pass
+    - [x] return None
+- [x] __str__ overrides
+    - [x] metadata.naming.LocalName
+    - [x] metadata.naming.ScopedName
+    - [x] metadata.naming.TypeName
+    - [x] metadata.naming.MemberName
+- [x] `PT_Locale`
+    - [x] Webscrape ISO 639-2 codes and store as JSON file (part of Joekulsarlon project)
+        - [x] Fix Static type checking errors.
+        - [x] Change process to save to parquet and JSON.
+        - [x] Double-check parquet file for custom metadata, which is stored in the schema's metadata
+        - [x] Convert JSON to Python Enum
+    - [x] Webscrape ISO 3166-1 country codes and store in JSON and parquet files (part of Joekulsarlon project)
+        - [x] convert JSON to Python Enum
+    - [-] Webscrape IANA Character Sets and store in parquet file (part of Joekulsarlon project)
+        - [-] Convert JSON to Python Enum
+    - [x] Replace PT_Locale with `str` conforming to **IETF BCP 47**
+    - [x] `metadata.acquisition.InstrumentEventList.locale`
+    - [x] `metadata.base.Metadata`
+        - [x] default_locale
+        - [x] other_locale
+    - [x] `metadata.identification.DataIdentification`
+        - [x] default_locale
+        - [x] other_locale
+- [x] Check for occurences in 19115-1, 19115-2
+    - [x] Set
+        - [x] ScopeDescription
+    - [x] Bag
+    - [x] Dictionary
+- [-] `PT_LocaleContainer` -> InternationalString (already noted as a `str` in docs 7.2.8)
+    - [-] to_string(Locale)
+- [x] `URI` --> `str`
+    - [x] `metadata.identification.KeywordClass.concept_identifier`
+- [x] `Direct Position`: ISO 19103:2015 p. 14 --> already implemented in geometry.primitive from ISO 19107:2019 p. 45
+        - [x] `metadata.representation.GCP.geographic_coordinates`
+        - [x] add `coordinatte` attribute
+- [x] Add code documentation to indicate which attributes/properties/fields are mandatory for ISO 19115-1:2014
+- [x] Fix data types for unannotated objects and attributes
+- [X] Finish incomplete code documentation
+    - [x] Add missing class and attribute descriptions
+    - [x] Add definition for each CodeList value in its corresponding Enum class.
+        - [x] metadata.citation
+        - [x] metadata.content
+        - [x] metadata.identification
+        - [x] metadata.quality
+        - [x] metadata.representation
+        - [x] referencing.crs
+    - [X] Change references in docstrings from MD_SomeObject (e.g., GM_Object, SV_OperationMetadata) to the python object
+- [x] Fix data types for abstraction in ISO 19103, ISO 19107
+    - [x] metadata.content
+    - [x] metadata.extent
+    - [x] metadata.identification
+    - [x] metadata.lineage
+    - [x] metadata.quality
+    - [x] metadata.representation
+    - [x] referencing.coordinate
+    - [x] referencing.crs
+    - [x] ISO 19103:2005
+        - [x] `UnitOfMeasure`: ISO 19103:2015 p. 44
+            - [x] `metadata.quality.QuantitativeResult.value_unit`
+        - [x] `Distance`: ISO 19103:2015 p. 44
+            - [x] `metadata.identification.Resolution`
+                - [x] .distance
+                - [x] .vertical
+            - [x] `metadata.lineage.NominalResolution`
+                - [x] .scanning_resolution
+                - [x] .ground_resolution
+        - [x] `Angle`: ISO 19103:2015 p. 44
+            - [x] `metadata.identification.Resolution`
+                - [x] .angular_distance
+        - [x] `Measure`: ISO 19103.2015 p. 44
+            - [x] `referencing.core.DataEpoch.coordinate_epoch`
+    - [x] ISO 19107
+        - [x] `GM_Object`
+            - [x] `metadata.extent.BoundingPolygon`
+                - [x] polygon
+        - [x] `GM_Point`
+            - [x] `metadata.representation.Georectified`
+                - [x] corner_points
+                - [x] cetre_point
+    - [x] Add ISO 19111:2019 updates
+            - [x] ObjectDomain
+            - [x] IdentifiedObject
+            - [x] `IdentifiedObject.to_wkt`
+    - [-] ISO 19110
+        - [-] FC_FeatureCatalogue
+            - [-] metadata.content
+
+- [x] Add Python mappings to [documentation](https://www.metanorma.org/author/ogc/)
+    - src > main > metanorma
+    - [x] 7.1.3.1 Departures from ISO model
+    - [x] 7.2.1 Primitive types
+        - [x] LanguageCode
+        - [x] CharacterSetCode
+    - [x] 7.2.2 Date and Time mappings (ISO 19103:2015 §7.2.2 to 7.2.4)
+        - [x] Date: datetime.date
+        - [x] Time: datetime.time
+        - [x] DateTime: datetime.datetime
+        - [x] TM_Duration: datetime.timedelta
+        - [x] TM_PeriodDuration: datetime.timedelta
+            - [x] `metadata.extent.TemporalExtent.extent`: make sure datetime.timedelta the right data type to return -> nope, returns a tuple[datetime, datetime] with the first component being the beginning and the second being the end.
+        - [x] TM_Primitive: datetime.datetime
+        - [x] Update documentation
+    - [x] 7.2.3 Collections (ISO 19103:2015 §7.3)
+        - [x] Bag --> `Sequence`
+        - [x] Set --> `Set`
+        - [x] Dictionary --> `dict`
+    - [x] 7.3.2 ReferenceSystem
+        - MD_ReferenceSystem -> `referencing.crs.ReferenceSystem`
+            - [x] added
+                - `reference_system_identifier`
+                - `reference_system_type`

--- a/geoapi/src/test/python/test_metadata.py
+++ b/geoapi/src/test/python/test_metadata.py
@@ -26,7 +26,7 @@ from opengis.metadata.citation       import Citation
 import unittest
 
 #
-# Information about a data set: title, where they are located, authors, etc.
+# Information about a dataset: title, where they are located, authors, etc.
 # For this demo, we provide only the title and an abstract. Since this demo
 # establishes a one-to-one relationship between data identification and the
 # citation (i.e. the title), we implement both interfaces in the same class
@@ -36,18 +36,22 @@ import unittest
 
 class IdentificationMock(DataIdentification, Citation):
     @property
+    @abstractmethod
     def citation(self):
         return self
 
     @property
+    @abstractmethod
     def title(self):
         return "Pseudo data"
 
     @property
+    @abstractmethod
     def abstract(self):
         return "A metadata with hard-coded values for demonstration purpose."
 
     @property
+    @abstractmethod
     def language(self):
         return "English"
         # TODO: what is the Python equivalent of java.util.Locale?
@@ -60,14 +64,17 @@ class IdentificationMock(DataIdentification, Citation):
 
 class MetadataMock(Metadata):
     @property
+    @abstractmethod
     def identification_info(self):
         return [IdentificationMock()]
 
     @property
+    @abstractmethod
     def contact(self):
         return []
 
     @property
+    @abstractmethod
     def date_info(self):
         return []
 

--- a/src/main/metanorma/sections/informative/collections.adoc
+++ b/src/main/metanorma/sections/informative/collections.adoc
@@ -13,10 +13,10 @@ A `Sequence` is similar to a `Bag` except that elements are ordered.
 |========================================================
 |ISO 19103 interface |Java type              |Python type
 |`Collection`        |`java.util.Collection` |`Sequence`
-|`Bag`               |`java.util.Collection` |
-|`Set`               |`java.util.Set`        |
+|`Bag`               |`java.util.Collection` |`Sequence`
+|`Set`               |`java.util.Set`        |`Set`
 |`Sequence`          |`java.util.List`       |`Sequence`
-|`Dictionary`        |`java.util.Map`        |
+|`Dictionary`        |`java.util.Map`        |`dict`
 |========================================================
 
 Unless otherwise required by the semantic of a property, GeoAPI prefers to use the `Collection` type in Java method signatures.

--- a/src/main/metanorma/sections/informative/controlled_vocabulary.adoc
+++ b/src/main/metanorma/sections/informative/controlled_vocabulary.adoc
@@ -18,14 +18,14 @@ For the open case, GeoAPI defines the `Code­List` abstract class in Java.
 
 .Enumerated types mapping
 [options="header"]
-|========================================================
+|===========================================================
 |ISO 19103 type |Java type                   |Python type
-|CodeList       |`org.opengis.util.CodeList` |`Enum` ^(1)^
+|CodeList       |`org.opengis.util.CodeList` |`Enum`  ^(1)^ 
 |Enumeration    |`java.lang.Enum`            |`Enum`
-|`Bit`          |unimplemented               |
-|`Digit`        |unimplemented               |
-|`Sign`         |unimplemented               |
-|========================================================
+|`Bit`          |unimplemented               |unimplemented 
+|`Digit`        |unimplemented               |unimplemented 
+|`Sign`         |unimplemented               |unimplemented 
+|===========================================================
 
 Notes:
 

--- a/src/main/metanorma/sections/informative/datetime.adoc
+++ b/src/main/metanorma/sections/informative/datetime.adoc
@@ -19,13 +19,13 @@ for letting developers choose how they want to handle timezones.
 
 .Date and time types suggested mapping
 [options="header"]
-|=========================================================================
+|==================================================================================
 |ISO 19103 interface   |Suggested Java class                  |Python type
-|`Date`                |`java.time.LocalDate`     ^(1)^ ^(2)^ |
-|`Time`                |`java.time.OffsetTime`    ^(1)^       |
-|`DateTime`            |`java.time.ZonedDateTime` ^(1)^ ^(2)^ |`datetime`
+|`Date`                |`java.time.LocalDate`     ^(1)^ ^(2)^ |`datetime.date`
+|`Time`                |`java.time.OffsetTime`    ^(1)^       |`datetime.time`
+|`DateTime`            |`java.time.ZonedDateTime` ^(1)^ ^(2)^ |`datetime.datetime` 
 |(none)                |`java.time.Instant`             ^(2)^ |
-|=========================================================================
+|==================================================================================
 
 Notes:
 

--- a/src/main/metanorma/sections/informative/generic_name.adoc
+++ b/src/main/metanorma/sections/informative/generic_name.adoc
@@ -60,7 +60,7 @@ The general rule is to use the name used in UML diagrams of OGC/ISO standards.
 
 .Standard type names and mapping to programming languages
 [options="header"]
-|===============================================================================
+|============================================================================================
 |Scoped type name      |Java class                                 |Python class
 |`OGC:Boolean`         |`java.lang.Boolean`                        |`int`
 |`OGC:Integer`         |`java.lang.Integer`                        |`int`
@@ -68,14 +68,21 @@ The general rule is to use the name used in UML diagrams of OGC/ISO standards.
 |`OGC:Decimal`         |`java.math.BigDecimal`                     |`float`
 |`OGC:CharacterString` |`java.lang.String`                         |`str`
 |`OGC:FreeText`        |`org.opengis.util.InternationalString`     |`str`
-|`OGC:PT_Locale`       |`java.util.Locale`                         |
-|`OGC:DateTime`        |`java.time.ZonedDateTime`                  |
+|`OGC:PT_Locale`       |`java.util.Locale`                         |`str`               ^(1)^ 
+|`OGC:DateTime`        |`java.time.ZonedDateTime`                  |`datetime.datetime` ^(2)^ 
 |`OGC:URI`             |`java.net.URI`                             |`str`
 |`OGC:Matrix`          |`org.opengis.referencing.operation.Matrix` |`np.ndarray`
 |`OGC:Coverage`        |`org.opengis.coverage.Coverage`            |`Coverage`
 |`OGC:MD_Metadata`     |`org.opengis.metadata.Metadata`            |`Metadata`
-|===============================================================================
+|============================================================================================
 
+Notes:
+
+* (1) A string conforming to the Internet Engineering Task Force Best Current
+Practices 47 (https://datatracker.ietf.org/doc/bcp47/[IETF BCP 47]) standard.
+* (2) The `datetime` object should be aware, that is the the time zone should be specified.
+For more information, see 
+https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive[Python's `datetime` module documentation].
 
 [[generic_name_departures]]
 ===== Departures from ISO model

--- a/src/main/metanorma/sections/informative/internationalization.adoc
+++ b/src/main/metanorma/sections/informative/internationalization.adoc
@@ -31,9 +31,9 @@ An example in <<International­String>> shows the use of `International­String`
 |ISO 19103 interface      |Java class or interface                |Python class
 |`CharacterString`        |`java.lang.String`               ^(1)^ |`str`
 |`LanguageString`         |`org.opengis.util.InternationalString` |`str`
-|`LanguageCode`           |`java.util.Locale`                     |
+|`LanguageCode`           |`java.util.Locale`                     |`str`
 |`Currency`         ^(2)^ |`java.util.Currency`                   |
-|`CharacterSetCode` ^(3)^ |`java.nio.charset.Charset`             |
+|`CharacterSetCode` ^(3)^ |`java.nio.charset.Charset`             |`str`
 |==============================================================================
 
 Notes:

--- a/src/main/metanorma/sections/informative/temporal/index.adoc
+++ b/src/main/metanorma/sections/informative/temporal/index.adoc
@@ -32,18 +32,19 @@ These replacements are suggestions; GeoAPI generally does not mandate this mappi
 
 .ISO 19108 interfaces omitted in favor of standard interfaces of target languages
 [options="header"]
-|=============================================================================
+|=======================================================================================
 |Omitted ISO 19108 interface |Suggested Java class                |Python type
 |`TM_CalDate`                |`java.time.LocalDate`               |
 |`TM_CalendarEra`            |`java.time.chrono.IsoEra`           |
-|`TM_ClockTime`              |`java.time.LocalTime`               |
-|`TM_DateAndTime`            |`java.time.LocalDateTime`           |
+|`TM_ClockTime`              |`java.time.LocalTime`               |`datetime.time`      
+|`TM_DateAndTime`            |`java.time.LocalDateTime`           |`datetime.datetime`  
 |`TM_Duration`               |`java.time.temporal.TemporalAmount` |
-|`TM_IntervalLength`         |`java.time.Duration`                |
+|`TM_IntervalLength`         |`java.time.Duration`                |`datetime.timedelta` 
 |`TM_OrdinalEra`             |`java.time.chrono.Era`              |
-|`TM_PeriodDuration`         |`java.time.Period`                  |
-|`TM_TemporalPosition`       |`java.time.temporal.Temporal`       |`datetime`
-|=============================================================================
+|`TM_PeriodDuration`         |`java.time.Period`                  |`datetime.timedelta` 
+|`TM_Primitive`              |                                    |`datetime.datetime`  
+|`TM_TemporalPosition`       |`java.time.temporal.Temporal`       |`datetime.datetime`  
+|=======================================================================================
 
 Note that despite their similar names,
 `java.time.Instant` is not equivalent to `TM_Instant` and

--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -21,7 +21,7 @@
 # Generate pip package
 # Author: Johann Sorel (Geomatys)
 #
-# Note: this file is called twice: by build.py and by pip install.
+# NOTE: this file is called twice: by build.py and by pip install.
 ##################################################################
 
 import setuptools


### PR DESCRIPTION
This PR updates the `metadata` subpackage and the directly related objects in the `referencing`, `geometry`, and `util` subpackages to the following current ISO standards:
- 19115-1:2014 (Except for MD_FeatureCatalogue)
    - 19115-1 Addendum 1 (2018)
    - 19115-1 Addendum 2 (2020)
- 19115-2:2018
    - 19115-2 Addendum 1 (2022)

The `util` subpackage is a new addition to GeoAPI's Python package and includes a `measure` module that has Measure, DirectedMeasure, and UnitOfMeasure abstract classes derived from ISO 19103:2015.

In addition, properties of abstract classes have been updated with the `@abstractmethod` decorator to define them as abstract properties, thus enabling the `pass` and `return None` statements to be removed.

Furthermore, docstrings have been more fully developed for the updated sections of code, including documenting the individual values for enumerations.