### PR TITLE
FIX: Circular import errors

### DIFF
--- a/geoapi/src/main/python/opengis/geometry/primitive.py
+++ b/geoapi/src/main/python/opengis/geometry/primitive.py
@@ -21,17 +21,20 @@ This module contains primitive geometry data structures derived from
 the ISO 19107 international standard.
 """
 
-__author__ = "OGC Topic 1 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
 from typing import Optional
 
-from opengis.referencing.crs import CoordinateReferenceSystem
-from opengis.referencing.cs import CoordinateSystem
-from opengis.util.measure import Angle, Length
+import opengis.referencing.crs as crs
+import opengis.referencing.cs as cs
+import opengis.util.measure as measure
+
+
+__author__ = "OGC Topic 1 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class CurveRelativeDirection(Enum):
@@ -120,7 +123,7 @@ class DirectPosition(ABC):
 
     @property
     @abstractmethod
-    def coordinate_reference_system(self) -> 'CoordinateReferenceSystem':
+    def coordinate_reference_system(self) -> crs.CoordinateReferenceSystem:
         """
         The coordinate reference system in which the coordinate tuple is given.
         """
@@ -229,7 +232,7 @@ class Bearing(ABC):
 
     @property
     @abstractmethod
-    def angle(self) -> Sequence['Angle']:
+    def angle(self) -> Sequence[measure.Angle]:
         """
         In this variant of Bearing, generally used for 2D coordinate systems,
         the first angle (azimuth) is measured from a coordinate axis (usually
@@ -297,7 +300,7 @@ class Vector(ABC):
                  position: DirectPosition,
                  coordinates: float | None = None,
                  direction: Bearing | None = None,
-                 length: 'Length | None' = None,
+                 length: measure.Length | None = None,
                  ) -> None:
         """
         The constructor vector creates a vector with the given offsets or
@@ -346,7 +349,7 @@ class Vector(ABC):
 
     @property
     @abstractmethod
-    def coordinate_system(self) -> 'CoordinateSystem':
+    def coordinate_system(self) -> cs.CoordinateSystem:
         """
         The `coordinate_system` attribute is the origin system and, therefore,
         determines the coordinates of the local tangent space in which the
@@ -447,7 +450,7 @@ class Geometry(TransfiniteSetOfDirectPositions):
 
     @property
     @abstractmethod
-    def coordinate_reference_system(self) -> 'CoordinateReferenceSystem':
+    def coordinate_reference_system(self) -> crs.CoordinateReferenceSystem:
         """
         The coordinate reference system in which the coordinate geometry
         is given.

--- a/geoapi/src/main/python/opengis/metadata/acquisition.py
+++ b/geoapi/src/main/python/opengis/metadata/acquisition.py
@@ -22,9 +22,7 @@ acquisition that are derived from the ISO 19115-2:2019 international
 standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
-
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -32,12 +30,16 @@ from datetime import date, datetime
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import Citation, Identifier, Responsibility
-from opengis.metadata.constraints import Constraints
-from opengis.metadata.extent import Extent
-from opengis.metadata.identification import ProgressCode
-from opengis.metadata.maintenance import Scope
-from opengis.metadata.naming import Record, RecordType
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.constraints as meta_constraints
+import opengis.metadata.extent as meta_extent
+import opengis.metadata.identification as meta_identification
+import opengis.metadata.maintenance as meta_maintenance
+import opengis.metadata.naming as meta_naming
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class ContextCode(Enum):
@@ -204,7 +206,7 @@ class Revision(ABC):
 
     @property
     @abstractmethod
-    def responsible_party(self) -> Sequence[Responsibility]:
+    def responsible_party(self) -> Sequence[meta_citation.Responsibility]:
         """Individual or organisation responsible for the revision."""
 
     @property
@@ -218,7 +220,7 @@ class InstrumentEvent(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Optional[Sequence[Citation]]:
+    def citation(self) -> Optional[Sequence[meta_citation.Citation]]:
         """Citation to the `InstrumentEvent`."""
 
     @property
@@ -228,7 +230,7 @@ class InstrumentEvent(ABC):
 
     @property
     @abstractmethod
-    def extent(self) -> Optional[Sequence[Extent]]:
+    def extent(self) -> Optional[Sequence[meta_extent.Extent]]:
         """Extent of the `InstrumentEvent`."""
 
     @property
@@ -247,7 +249,7 @@ class InstrumentEventList(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Optional[Sequence[Citation]]:
+    def citation(self) -> Optional[Sequence[meta_citation.Citation]]:
         """Citation to the `InstrumentEventList`."""
 
     @property
@@ -268,7 +270,7 @@ class InstrumentEventList(ABC):
 
     @property
     @abstractmethod
-    def constraints(self) -> Optional[Sequence[Constraints]]:
+    def constraints(self) -> Optional[Sequence[meta_constraints.Constraints]]:
         """Use and access constraints."""
 
     @property
@@ -282,12 +284,12 @@ class Instrument(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Optional[Sequence[Citation]]:
+    def citation(self) -> Optional[Sequence[meta_citation.Citation]]:
         """Complete citation of the instrument."""
 
     @property
     @abstractmethod
-    def identifier(self) -> Identifier:
+    def identifier(self) -> meta_citation.Identifier:
         """Unique identification of the instrument."""
 
     @property
@@ -333,12 +335,12 @@ class Platform(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Optional[Citation]:
+    def citation(self) -> Optional[meta_citation.Citation]:
         """Complete citation of the platform."""
 
     @property
     @abstractmethod
-    def identifier(self) -> Identifier:
+    def identifier(self) -> meta_citation.Identifier:
         """Unique identification of the platform."""
 
     @property
@@ -348,7 +350,7 @@ class Platform(ABC):
 
     @property
     @abstractmethod
-    def sponsor(self) -> Optional[Sequence[Responsibility]]:
+    def sponsor(self) -> Optional[Sequence[meta_citation.Responsibility]]:
         """
         Organisation responsible for building, launch, or operation of the
         platform.
@@ -356,12 +358,12 @@ class Platform(ABC):
 
     @property
     @abstractmethod
-    def other_property(self) -> Optional[Record]:
+    def other_property(self) -> Optional[meta_naming.Record]:
         """Instance of other property type not included in `Sensor`."""
 
     @property
     @abstractmethod
-    def other_property_type(self) -> Optional[RecordType]:
+    def other_property_type(self) -> Optional[meta_naming.RecordType]:
         """Type of other property description."""
 
     @property
@@ -383,12 +385,12 @@ class PlatformPass(ABC):
 
     @property
     @abstractmethod
-    def identifier(self) -> Identifier:
+    def identifier(self) -> meta_citation.Identifier:
         """Unique name of the pass."""
 
     @property
     @abstractmethod
-    def extent(self) -> Optional[Extent]:
+    def extent(self) -> Optional[meta_extent.Extent]:
         """Temporal and spatial extent of the pass."""
 
     @property
@@ -405,7 +407,7 @@ class Event(ABC):
 
     @property
     @abstractmethod
-    def identifier(self) -> Identifier:
+    def identifier(self) -> meta_citation.Identifier:
         """Event name or number."""
 
     @property
@@ -506,7 +508,7 @@ class Objective(ABC):
 
     @property
     @abstractmethod
-    def identifier(self) -> Sequence[Identifier]:
+    def identifier(self) -> Sequence[meta_citation.Identifier]:
         """Registered code used to identify the objective."""
 
     @property
@@ -526,7 +528,7 @@ class Objective(ABC):
 
     @property
     @abstractmethod
-    def extent(self) -> Optional[Sequence[Extent]]:
+    def extent(self) -> Optional[Sequence[meta_extent.Extent]]:
         """
         Extent information including the bounding box, bounding polygon,
         vertical and temporal extent of the objective.
@@ -561,17 +563,17 @@ class Operation(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Optional[Citation]:
+    def citation(self) -> Optional[meta_citation.Citation]:
         """Identification of the mission."""
 
     @property
     @abstractmethod
-    def identifier(self) -> Optional[Identifier]:
+    def identifier(self) -> Optional[meta_citation.Identifier]:
         """Unique identification of the operation."""
 
     @property
     @abstractmethod
-    def status(self) -> ProgressCode:
+    def status(self) -> meta_identification.ProgressCode:
         """Status of the data acquisition."""
 
     @property
@@ -581,12 +583,12 @@ class Operation(ABC):
 
     @property
     @abstractmethod
-    def other_property(self) -> Optional[Record]:
+    def other_property(self) -> Optional[meta_naming.Record]:
         """Instance of other property type not included in `Sensor`."""
 
     @property
     @abstractmethod
-    def other_property_type(self) -> Optional[RecordType]:
+    def other_property_type(self) -> Optional[meta_naming.RecordType]:
         """Type of other property description."""
 
     @property
@@ -639,24 +641,24 @@ class Requirement(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Optional[Citation]:
+    def citation(self) -> Optional[meta_citation.Citation]:
         """
         Identification of reference or guidance material for the requirement.
         """
 
     @property
     @abstractmethod
-    def identifier(self) -> Identifier:
+    def identifier(self) -> meta_citation.Identifier:
         """Unique name, or code, for the requirement."""
 
     @property
     @abstractmethod
-    def requestor(self) -> Sequence[Responsibility]:
+    def requestor(self) -> Sequence[meta_citation.Responsibility]:
         """Origin of requirement."""
 
     @property
     @abstractmethod
-    def recipient(self) -> Sequence[Responsibility]:
+    def recipient(self) -> Sequence[meta_citation.Responsibility]:
         """Person(s), or body(ies), to receive results of requirement."""
 
     @property
@@ -695,12 +697,12 @@ class Plan(ABC):
 
     @property
     @abstractmethod
-    def status(self) -> ProgressCode:
+    def status(self) -> meta_identification.ProgressCode:
         """Current status of the plan (pending, completed, etc.)."""
 
     @property
     @abstractmethod
-    def citation(self) -> Citation:
+    def citation(self) -> meta_citation.Citation:
         """Identification of authority requesting target collection."""
 
     @property
@@ -722,7 +724,7 @@ class AcquisitionInformation(ABC):
 
     @property
     @abstractmethod
-    def scope(self) -> Optional[Sequence[Scope]]:
+    def scope(self) -> Optional[Sequence[meta_maintenance.Scope]]:
         """The specific data to which the acquisition information applies."""
 
     @property

--- a/geoapi/src/main/python/opengis/metadata/base.py
+++ b/geoapi/src/main/python/opengis/metadata/base.py
@@ -22,21 +22,14 @@ acquisition that are derived from theISO 19115-1:2014 and ISO 19115-2:2019
 international standards.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Optional
 
-from opengis.metadata.acquisition import AcquisitionInformation
-from opengis.metadata.citation import (
-    Citation,
-    Date,
-    Identifier,
-    OnlineResource,
-    Responsibility,
-)
+import opengis.metadata.acquisition as meta_acquisition
+import opengis.metadata.citation as meta_citation
 from opengis.metadata.constraints import Constraints
 from opengis.metadata.content import ContentInformation
 from opengis.metadata.distribution import Distribution
@@ -52,12 +45,16 @@ from opengis.metadata.representation import SpatialRepresentation
 from opengis.referencing.crs import ReferenceSystem
 
 
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+
+
 class PortrayalCatalogueReference(ABC):
     """Information identifying the portrayal catalogue used."""
 
     @property
     @abstractmethod
-    def portrayal_catalogue_citation(self) -> Sequence[Citation]:
+    def portrayal_catalogue_citation(self) -> Sequence[meta_citation.Citation]:
         """Bibliographic reference to the portrayal catalogue cited."""
 
 
@@ -80,7 +77,7 @@ class Metadata(ABC):
 
     @property
     @abstractmethod
-    def metadata_identifier(self) -> Optional[Identifier]:
+    def metadata_identifier(self) -> Optional[meta_citation.Identifier]:
         """Unique identifier for this metadata record."""
 
     @property
@@ -96,7 +93,7 @@ class Metadata(ABC):
 
     @property
     @abstractmethod
-    def parent_metadata(self) -> Optional[Citation]:
+    def parent_metadata(self) -> Optional[meta_citation.Citation]:
         """
         Identification of the parent metadata record.
 
@@ -106,12 +103,12 @@ class Metadata(ABC):
 
     @property
     @abstractmethod
-    def contact(self) -> Sequence[Responsibility]:
+    def contact(self) -> Sequence[meta_citation.Responsibility]:
         """Party responsible for the metadata information."""
 
     @property
     @abstractmethod
-    def date_info(self) -> Sequence[Date]:
+    def date_info(self) -> Sequence[meta_citation.Date]:
         """
         Date(s) associated with the metadata.
 
@@ -120,7 +117,7 @@ class Metadata(ABC):
 
     @property
     @abstractmethod
-    def metadata_standard(self) -> Optional[Sequence[Citation]]:
+    def metadata_standard(self) -> Optional[Sequence[meta_citation.Citation]]:
         """
         Citation for the standards to which the metadata conforms.
 
@@ -129,7 +126,7 @@ class Metadata(ABC):
 
     @property
     @abstractmethod
-    def metadata_profile(self) -> Optional[Sequence[Citation]]:
+    def metadata_profile(self) -> Optional[Sequence[meta_citation.Citation]]:
         """
         Citation(s) for the profile(s) of the metadata standard to which the
         metadata conform.
@@ -139,7 +136,8 @@ class Metadata(ABC):
 
     @property
     @abstractmethod
-    def alternative_metadata_reference(self) -> Optional[Sequence[Citation]]:
+    def alternative_metadata_reference(self) -> \
+            Optional[Sequence[meta_citation.Citation]]:
         """
         Reference to alternative metadata,e.g., Dublin Core, FGDC, or metadata
         in a non-ISO standard for the same resource.
@@ -155,7 +153,8 @@ class Metadata(ABC):
 
     @property
     @abstractmethod
-    def metadata_linkage(self) -> Optional[Sequence[OnlineResource]]:
+    def metadata_linkage(self) -> \
+            Optional[Sequence[meta_citation.OnlineResource]]:
         """Online location where the metadata is available."""
 
     @property
@@ -268,6 +267,6 @@ class Metadata(ABC):
     @property
     @abstractmethod
     def acquisition_information(self) -> Optional[
-        Sequence[AcquisitionInformation]
+        Sequence[meta_acquisition.AcquisitionInformation]
     ]:
         """Information about the acquisition of the data."""

--- a/geoapi/src/main/python/opengis/metadata/citation.py
+++ b/geoapi/src/main/python/opengis/metadata/citation.py
@@ -21,8 +21,7 @@ This module contains geographic metadata structures regarding metadata
 citations derived from the ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -30,8 +29,12 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.extent import Extent
-from opengis.metadata.identification import BrowseGraphic
+import opengis.metadata.extent as meta_extent
+import opengis.metadata.identification as meta_identification
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class DateTypeCode(Enum):
@@ -589,7 +592,7 @@ class Responsibility(ABC):
 
     @property
     @abstractmethod
-    def extent(self) -> Optional[Sequence['Extent']]:
+    def extent(self) -> Optional[Sequence[meta_extent.Extent]]:
         """Spatial or temporal extent of the role."""
 
     @property
@@ -617,7 +620,7 @@ class Organisation(Party):
 
     @property
     @abstractmethod
-    def logo(self) -> Sequence[BrowseGraphic]:
+    def logo(self) -> Sequence[meta_identification.BrowseGraphic]:
         """
         Graphic identifying organisation.
 
@@ -730,7 +733,7 @@ class Citation(ABC):
 
     @property
     @abstractmethod
-    def graphic(self) -> Optional[Sequence['BrowseGraphic']]:
+    def graphic(self) -> Optional[Sequence[meta_identification.BrowseGraphic]]:
         """Citation graphic or logo for cited party."""
 
 

--- a/geoapi/src/main/python/opengis/metadata/constraints.py
+++ b/geoapi/src/main/python/opengis/metadata/constraints.py
@@ -21,20 +21,20 @@ This module contains geographic metadata structures regarding data constraints
 derived from the ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import (
-    Citation,
-    Responsibility,
-)
-from opengis.metadata.identification import BrowseGraphic
-from opengis.metadata.maintenance import Scope
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.identification as meta_identification
+import opengis.metadata.maintenance as meta_maintenance
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class ClassificationCode(Enum):
@@ -169,7 +169,7 @@ class Releasability(ABC):
 
     @property
     @abstractmethod
-    def addressee(self) -> Optional[Sequence[Responsibility]]:
+    def addressee(self) -> Optional[Sequence[meta_citation.Responsibility]]:
         """
         Party to which the release statement applies.
 
@@ -206,7 +206,7 @@ class Constraints(ABC):
 
     @property
     @abstractmethod
-    def constraint_application_scope(self) -> Optional[Scope]:
+    def constraint_application_scope(self) -> Optional[meta_maintenance.Scope]:
         """
         Spatial and temporal extent of the application of the constraint
         restrictions.
@@ -214,7 +214,7 @@ class Constraints(ABC):
 
     @property
     @abstractmethod
-    def graphic(self) -> Optional[Sequence[BrowseGraphic]]:
+    def graphic(self) -> Optional[Sequence[meta_identification.BrowseGraphic]]:
         """Graphic /symbol indicating the constraint.
 
         Example:
@@ -224,7 +224,7 @@ class Constraints(ABC):
 
     @property
     @abstractmethod
-    def reference(self) -> Optional[Sequence[Citation]]:
+    def reference(self) -> Optional[Sequence[meta_citation.Citation]]:
         """
         Citation/URL for the limitation or constraint,
         e.g., copyright statement, license agreement, etc.
@@ -241,7 +241,8 @@ class Constraints(ABC):
 
     @property
     @abstractmethod
-    def responsible_party(self) -> Optional[Sequence[Responsibility]]:
+    def responsible_party(self) -> \
+            Optional[Sequence[meta_citation.Responsibility]]:
         """Party responsible for the resource constraints."""
 
 

--- a/geoapi/src/main/python/opengis/metadata/content.py
+++ b/geoapi/src/main/python/opengis/metadata/content.py
@@ -21,17 +21,21 @@ This module contains geographic metadata structures regarding data content
 derived from the ISO 19115-1:2014 and ISO 19115-2:2019 international standards.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
+
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import Citation, Identifier
-from opengis.metadata.naming import GenericName, MemberName, Record, RecordType
-from opengis.util.measure import UnitOfMeasure, UomLength
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.naming as meta_naming
+import opengis.util.measure as measure
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class BandDefinition(Enum):
@@ -247,7 +251,7 @@ class RangeElementDescription(ABC):
 
     @property
     @abstractmethod
-    def range_element(self) -> Sequence[Record]:
+    def range_element(self) -> Sequence[meta_naming.Record]:
         """
         Specific range elements, i.e. range elements associated with a name
         and their definition.
@@ -259,7 +263,7 @@ class RangeDimension(ABC):
 
     @property
     @abstractmethod
-    def sequence_identifier(self) -> Optional[MemberName]:
+    def sequence_identifier(self) -> Optional[meta_naming.MemberName]:
         """
         Number that uniquely identifies instances of bands of wavelengths on
         which a sensor operates.
@@ -272,7 +276,7 @@ class RangeDimension(ABC):
 
     @property
     @abstractmethod
-    def name(self) -> Optional[Sequence[Identifier]]:
+    def name(self) -> Optional[Sequence[meta_citation.Identifier]]:
         """
         Identifiers for each attribute included in the resource.
 
@@ -325,7 +329,7 @@ class SampleDimension(RangeDimension):
 
     @property
     @abstractmethod
-    def units(self) -> Optional[UnitOfMeasure]:
+    def units(self) -> Optional[measure.UnitOfMeasure]:
         """
         Units of data in each dimension included in the resource.
 
@@ -371,14 +375,14 @@ class SampleDimension(RangeDimension):
 
     @property
     @abstractmethod
-    def other_property_type(self) -> Optional[RecordType]:
+    def other_property_type(self) -> Optional[meta_naming.RecordType]:
         """
         Type of other attribute description (i.e. netcdf/variable in ncml.xsd).
         """
 
     @property
     @abstractmethod
-    def other_property(self) -> Optional[Record]:
+    def other_property(self) -> Optional[meta_naming.Record]:
         """
         Instance of otherAttributeType that defines attributes not explicitly
         included in `CoverageType`.
@@ -438,7 +442,7 @@ class Band(SampleDimension):
 
     @property
     @abstractmethod
-    def bound_unit(self) -> Optional[UomLength]:
+    def bound_unit(self) -> Optional[measure.UomLength]:
         """
         Bounding units. The units in which the sensor wavelengths are
         expressed.
@@ -485,12 +489,12 @@ class CoverageDescription(ContentInformation):
 
     @property
     @abstractmethod
-    def attribute_description(self) -> RecordType:
+    def attribute_description(self) -> meta_naming.RecordType:
         """Description of the attribute described by the measurement value."""
 
     @property
     @abstractmethod
-    def processing_level_code(self) -> Optional[Identifier]:
+    def processing_level_code(self) -> Optional[meta_citation.Identifier]:
         """
         Code and codespace that identifies the level of processing that has
         been applied to the resource.
@@ -551,7 +555,7 @@ class ImageDescription(CoverageDescription):
 
     @property
     @abstractmethod
-    def image_quality_code(self) -> Optional[Identifier]:
+    def image_quality_code(self) -> Optional[meta_citation.Identifier]:
         """Code in producer's code space that specifies the image quality."""
 
     @property
@@ -618,7 +622,7 @@ class FeatureTypeInfo(ABC):
 
     @property
     @abstractmethod
-    def feature_type_name(self) -> GenericName:
+    def feature_type_name(self) -> meta_naming.GenericName:
         """Name of the feature type."""
 
     @property
@@ -670,7 +674,8 @@ class FeatureCatalogueDescription(ContentInformation):
 
     @property
     @abstractmethod
-    def feature_catalogue_citation(self) -> Optional[Sequence[Citation]]:
+    def feature_catalogue_citation(self) -> \
+            Optional[Sequence[meta_citation.Citation]]:
         """
         Complete bibliographic reference to one or more external feature
         catalogues.

--- a/geoapi/src/main/python/opengis/metadata/distribution.py
+++ b/geoapi/src/main/python/opengis/metadata/distribution.py
@@ -21,8 +21,7 @@ This module contains geographic metadata structures regarding data
 distribution derived from the ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -30,13 +29,12 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import (
-    Citation,
-    Identifier,
-    OnlineResource,
-    Responsibility,
-)
-from opengis.metadata.naming import GenericName, Record, RecordType
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.naming as meta_naming
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class MediumFormatCode(Enum):
@@ -69,7 +67,7 @@ class Medium(ABC):
 
     @property
     @abstractmethod
-    def name(self) -> Optional[Citation]:
+    def name(self) -> Optional[meta_citation.Citation]:
         """Name of the medium on which the resource can be received."""
 
     @property
@@ -109,7 +107,7 @@ class Medium(ABC):
 
     @property
     @abstractmethod
-    def identifier(self) -> Optional[Identifier]:
+    def identifier(self) -> Optional[meta_citation.Identifier]:
         """Unique identifier for an instance of the `Medium`."""
 
 
@@ -122,7 +120,7 @@ class Format(ABC):
 
     @property
     @abstractmethod
-    def format_specification_citation(self) -> Citation:
+    def format_specification_citation(self) -> meta_citation.Citation:
         """Citation/URL of the specification for the format."""
 
     @property
@@ -169,7 +167,7 @@ class DataFile(ABC):
 
     @property
     @abstractmethod
-    def feature_types(self) -> Sequence[GenericName]:
+    def feature_types(self) -> Sequence[meta_naming.GenericName]:
         """
         Provides the list of feature types concerned by the transfer data file.
         """
@@ -208,12 +206,12 @@ class StandardOrderProcess(ABC):
 
     @property
     @abstractmethod
-    def order_options_type(self) -> Optional[RecordType]:
+    def order_options_type(self) -> Optional[meta_naming.RecordType]:
         """Description of the order options record."""
 
     @property
     @abstractmethod
-    def order_options(self) -> Optional[Record]:
+    def order_options(self) -> Optional[meta_naming.Record]:
         """Request/purchase choices."""
 
 
@@ -222,7 +220,7 @@ class Distributor(ABC):
 
     @property
     @abstractmethod
-    def distributor_contact(self) -> Responsibility:
+    def distributor_contact(self) -> meta_citation.Responsibility:
         """
         Party from whom the resource may be obtained. This list need not be
         exhaustive.
@@ -316,7 +314,7 @@ class DigitalTransferOptions(ABC):
 
     @property
     @abstractmethod
-    def on_line(self) -> Optional[Sequence[OnlineResource]]:
+    def on_line(self) -> Optional[Sequence[meta_citation.OnlineResource]]:
         """
         Information about online sources from which the resource can be
         obtained.

--- a/geoapi/src/main/python/opengis/metadata/extension.py
+++ b/geoapi/src/main/python/opengis/metadata/extension.py
@@ -21,15 +21,18 @@ This module contains geographic metadata structures for metadata elements that
 are not contained in the ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import Citation, OnlineResource, Responsibility
+import opengis.metadata.citation as meta_citation
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class DatatypeCode(Enum):
@@ -132,7 +135,7 @@ class ApplicationSchemaInformation(ABC):
 
     @property
     @abstractmethod
-    def name(self) -> Citation:
+    def name(self) -> meta_citation.Citation:
         """Name of the application schema used."""
 
     @property
@@ -152,12 +155,13 @@ class ApplicationSchemaInformation(ABC):
 
     @property
     @abstractmethod
-    def graphics_file(self) -> Optional[OnlineResource]:
+    def graphics_file(self) -> Optional[meta_citation.OnlineResource]:
         """Full application schema given as a graphics file."""
 
     @property
     @abstractmethod
-    def software_development_file(self) -> Optional[OnlineResource]:
+    def software_development_file(self) -> \
+            Optional[meta_citation.OnlineResource]:
         """Full application schema given as a software development file."""
 
     @property
@@ -182,7 +186,7 @@ class ExtendedElementInformation(ABC):
         Name of the extended metadata element.
 
         MANDATORY:
-        
+
         if `data_type` != CODE_LIST and `datatype` != ENUMERATION
             and `data_type` != CODE_LIST_ELEMENT.
         """
@@ -267,7 +271,7 @@ class ExtendedElementInformation(ABC):
 
     @property
     @abstractmethod
-    def source(self) -> Sequence[Responsibility]:
+    def source(self) -> Sequence[meta_citation.Responsibility]:
         """Name of the person or organisation creating the extended element."""
 
     @property
@@ -297,7 +301,8 @@ class MetadataExtensionInformation(ABC):
 
     @property
     @abstractmethod
-    def extension_on_line_resource(self) -> Optional[OnlineResource]:
+    def extension_on_line_resource(self) -> \
+            Optional[meta_citation.OnlineResource]:
         """
         Information about on-line sources containing the community profile
         name and the extended metadata elements and information for all new

--- a/geoapi/src/main/python/opengis/metadata/extent.py
+++ b/geoapi/src/main/python/opengis/metadata/extent.py
@@ -21,17 +21,20 @@ This module contains geographic metadata structures regarding data extent
 derived from the ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Optional
 
-from opengis.geometry.primitive import Geometry
-from opengis.metadata.citation import Identifier
-from opengis.referencing.crs import ReferenceSystem, VerticalCRS
+import opengis.geometry.primitive as primitive
+import opengis.metadata.citation as meta_citation
+import opengis.referencing.crs as crs
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class VerticalExtent(ABC):
@@ -49,7 +52,7 @@ class VerticalExtent(ABC):
 
     @property
     @abstractmethod
-    def vertical_crs(self) -> Optional['VerticalCRS']:
+    def vertical_crs(self) -> Optional[crs.VerticalCRS]:
         """
         Provides information about the vertical coordinate reference system
         to which the maximum and minimum elevation values are measured.
@@ -65,7 +68,7 @@ class VerticalExtent(ABC):
 
     @property
     @abstractmethod
-    def vertical_crs_id(self) -> Optional['ReferenceSystem']:
+    def vertical_crs_id(self) -> Optional[crs.ReferenceSystem]:
         """
         Identifies the vertical coordinate reference system used for the
         minimum and maximum values.
@@ -107,7 +110,7 @@ class BoundingPolygon(GeographicExtent):
 
     @property
     @abstractmethod
-    def polygon(self) -> Sequence[Geometry]:
+    def polygon(self) -> Sequence[primitive.Geometry]:
         """
         Sets of points defining the bounding polygon or any other `Geometry`
         object (point, line, or polygon).
@@ -171,7 +174,7 @@ class GeographicDescription(GeographicExtent):
 
     @property
     @abstractmethod
-    def geographic_identifier(self) -> 'Identifier':
+    def geographic_identifier(self) -> meta_citation.Identifier:
         """
         Identifier used to represent a geographic area.
 

--- a/geoapi/src/main/python/opengis/metadata/identification.py
+++ b/geoapi/src/main/python/opengis/metadata/identification.py
@@ -22,8 +22,7 @@ information codelists and common base classes derived from the
 ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -31,18 +30,17 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import (
-    Citation,
-    Identifier,
-    OnlineResource,
-    Responsibility,
-)
-from opengis.metadata.constraints import Constraints
-from opengis.metadata.distribution import Format
-from opengis.metadata.extent import Extent
-from opengis.metadata.maintenance import MaintenanceInformation
-from opengis.metadata.representation import SpatialRepresentationTypeCode
-from opengis.util.measure import Angle, Distance
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.constraints as meta_constraints
+import opengis.metadata.distribution as meta_distribution
+import opengis.metadata.extent as meta_extent
+import opengis.metadata.maintenance as meta_maintenance
+import opengis.metadata.representation as meta_representation
+import opengis.util.measure as measure
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class AssociationTypeCode(Enum):
@@ -500,12 +498,13 @@ class BrowseGraphic(ABC):
 
     @property
     @abstractmethod
-    def image_constraints(self) -> Optional[Sequence[Constraints]]:
+    def image_constraints(self) -> \
+            Optional[Sequence[meta_constraints.Constraints]]:
         """Restriction on access and/or use of browse graphic."""
 
     @property
     @abstractmethod
-    def linkage(self) -> Optional[Sequence[OnlineResource]]:
+    def linkage(self) -> Optional[Sequence[meta_citation.OnlineResource]]:
         """Link to browse graphic."""
 
 
@@ -532,7 +531,7 @@ class KeywordClass(ABC):
 
     @property
     @abstractmethod
-    def ontology(self) -> Citation:
+    def ontology(self) -> meta_citation.Citation:
         """
         A reference that binds the keyword class to a formal conceptualization
         of a knowledge domain for use in semantic processing NOTE: Keywords in
@@ -564,7 +563,7 @@ class Keywords(ABC):
 
     @property
     @abstractmethod
-    def thesaurus_name(self) -> Optional[Citation]:
+    def thesaurus_name(self) -> Optional[meta_citation.Citation]:
         """
         Name of the formally registered thesaurus or a similar authoritative
         source of keywords.
@@ -618,7 +617,8 @@ class Usage(ABC):
 
     @property
     @abstractmethod
-    def user_contact_info(self) -> Optional[Sequence[Responsibility]]:
+    def user_contact_info(self) -> \
+            Optional[Sequence[meta_citation.Responsibility]]:
         """
         Identification of and means of communicating with person(s) and
         organisation(s) using the resource(s).
@@ -634,12 +634,13 @@ class Usage(ABC):
 
     @property
     @abstractmethod
-    def additional_documentation(self) -> Optional[Sequence[Citation]]:
+    def additional_documentation(self) -> \
+            Optional[Sequence[meta_citation.Citation]]:
         """Publications that describe usage of data."""
 
     @property
     @abstractmethod
-    def identified_issues(self) -> Optional[Sequence[Citation]]:
+    def identified_issues(self) -> Optional[Sequence[meta_citation.Citation]]:
         """
         Citation of a description of known issues associated with the resource
         along with proposed solutions if available.
@@ -680,7 +681,7 @@ class Resolution(ABC):
 
     @property
     @abstractmethod
-    def distance(self) -> Optional[Distance]:
+    def distance(self) -> Optional[measure.Distance]:
         """
         Horizontal ground sample distance.
 
@@ -691,7 +692,7 @@ class Resolution(ABC):
 
     @property
     @abstractmethod
-    def vertical(self) -> Optional[Distance]:
+    def vertical(self) -> Optional[measure.Distance]:
         """
         Vertical sampling distance.
 
@@ -702,7 +703,7 @@ class Resolution(ABC):
 
     @property
     @abstractmethod
-    def angular_distance(self) -> Optional[Angle]:
+    def angular_distance(self) -> Optional[measure.Angle]:
         """
         Angular sampling measure.
 
@@ -733,7 +734,7 @@ class AssociatedResource(ABC):
 
     @property
     @abstractmethod
-    def name(self) -> Optional[Citation]:
+    def name(self) -> Optional[meta_citation.Citation]:
         """
         Citation information about the associated resource.
 
@@ -757,7 +758,7 @@ class AssociatedResource(ABC):
 
     @property
     @abstractmethod
-    def metadata_reference(self) -> Optional[Citation]:
+    def metadata_reference(self) -> Optional[meta_citation.Citation]:
         """
         Reference to the metadata of the associated resource.
 
@@ -773,7 +774,7 @@ class Identification(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Citation:
+    def citation(self) -> meta_citation.Citation:
         """Citation for the resource(s)."""
 
     @property
@@ -799,7 +800,8 @@ class Identification(ABC):
 
     @property
     @abstractmethod
-    def point_of_contact(self) -> Optional[Sequence[Responsibility]]:
+    def point_of_contact(self) -> \
+            Optional[Sequence[meta_citation.Responsibility]]:
         """
         Identification of, and means of communication with, person(s) and
         organisation(s) associated with the resource(s).
@@ -808,7 +810,7 @@ class Identification(ABC):
     @property
     @abstractmethod
     def spatial_representation_type(self) -> Optional[Sequence[
-        SpatialRepresentationTypeCode
+        meta_representation.SpatialRepresentationTypeCode
     ]]:
         """Method used to spatially represent geographic information."""
 
@@ -838,7 +840,7 @@ class Identification(ABC):
 
     @property
     @abstractmethod
-    def extent(self) -> Optional[Sequence[Extent]]:
+    def extent(self) -> Optional[Sequence[meta_extent.Extent]]:
         """
         Spatial and temporal extent of the resource.
 
@@ -850,7 +852,8 @@ class Identification(ABC):
 
     @property
     @abstractmethod
-    def additional_documentation(self) -> Optional[Sequence[Citation]]:
+    def additional_documentation(self) -> \
+            Optional[Sequence[meta_citation.Citation]]:
         """
         Other documentation associated with the resource, e.g.,
         Related articles, publications, user guides, data dictionaries.
@@ -858,7 +861,8 @@ class Identification(ABC):
 
     @property
     @abstractmethod
-    def processing_level(self) -> Optional[Identifier]:
+    def processing_level(self) -> \
+            Optional[meta_citation.Identifier]:
         """
         Code that identifies the level of processing in the producers coding
         system of a resource, e.g., NOAA level 1B.
@@ -867,7 +871,7 @@ class Identification(ABC):
     @property
     @abstractmethod
     def resource_maintenance(self) -> Optional[Sequence[
-        MaintenanceInformation
+        meta_maintenance.MaintenanceInformation
     ]]:
         """
         Information about the frequency of resource updates and the scope of
@@ -884,7 +888,8 @@ class Identification(ABC):
 
     @property
     @abstractmethod
-    def resource_format(self) -> Optional[Sequence[Format]]:
+    def resource_format(self) -> \
+            Optional[Sequence[meta_distribution.Format]]:
         """Description of the format of the resource."""
 
     @property
@@ -902,7 +907,8 @@ class Identification(ABC):
 
     @property
     @abstractmethod
-    def resource_constraints(self) -> Optional[Sequence[Constraints]]:
+    def resource_constraints(self) -> \
+            Optional[Sequence[meta_constraints.Constraints]]:
         """Information about constraints which apply to the resource."""
 
     @property

--- a/geoapi/src/main/python/opengis/metadata/lineage.py
+++ b/geoapi/src/main/python/opengis/metadata/lineage.py
@@ -23,21 +23,24 @@ the lineage of the data, that is how the data has changed and the sources
 from which it is derived.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Optional
 
-from opengis.metadata.citation import Citation, Identifier, Responsibility
-from opengis.metadata.identification import Resolution
-from opengis.metadata.maintenance import Scope
-from opengis.metadata.naming import MemberName, Record, RecordType
-from opengis.metadata.service import ParameterDirection
-from opengis.referencing.crs import ReferenceSystem
-from opengis.util.measure import Distance
+import opengis.metadata.citation as meta_ctitation
+import opengis.metadata.identification as meta_identification
+import opengis.metadata.maintenance as meta_maintenance
+import opengis.metadata.naming as meta_naming
+import opengis.metadata.service as meta_service
+import opengis.referencing.crs as crs
+import opengis.util.measure as measure
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class NominalResolution(ABC):
@@ -48,7 +51,7 @@ class NominalResolution(ABC):
 
     @property
     @abstractmethod
-    def scanning_resolution(self) -> Distance:
+    def scanning_resolution(self) -> measure.Distance:
         """
         Distance between consistent parts (centre, left side, right side)
         of adjacent pixels in the scan plane.
@@ -56,7 +59,7 @@ class NominalResolution(ABC):
 
     @property
     @abstractmethod
-    def ground_resolution(self) -> Distance:
+    def ground_resolution(self) -> measure.Distance:
         """
         Distance between consistent parts (centre, left side, right side)
         of adjacent pixels in the object space.
@@ -81,29 +84,30 @@ class Source(ABC):
 
     @property
     @abstractmethod
-    def source_spatial_resolution(self) -> Optional[Resolution]:
+    def source_spatial_resolution(self) -> \
+            Optional[meta_identification.Resolution]:
         """
         Level of detail expressed as a scale factor, a distance or an angle.
         """
 
     @property
     @abstractmethod
-    def source_reference_system(self) -> Optional[ReferenceSystem]:
+    def source_reference_system(self) -> Optional[crs.ReferenceSystem]:
         """Spatial reference system used by the source resource."""
 
     @property
     @abstractmethod
-    def source_citation(self) -> Optional[Citation]:
+    def source_citation(self) -> Optional[meta_ctitation.Citation]:
         """Recommended reference to be used for the source resource."""
 
     @property
     @abstractmethod
-    def source_metadata(self) -> Optional[Sequence[Citation]]:
+    def source_metadata(self) -> Optional[Sequence[meta_ctitation.Citation]]:
         """Identifier and link to source metadata."""
 
     @property
     @abstractmethod
-    def scope(self) -> Optional[Scope]:
+    def scope(self) -> Optional[meta_maintenance.Scope]:
         """
         Type of resource and/or extent of the source.
 
@@ -118,7 +122,7 @@ class Source(ABC):
 
     @property
     @abstractmethod
-    def processed_level(self) -> Optional[Identifier]:
+    def processed_level(self) -> Optional[meta_ctitation.Identifier]:
         """Processing level of the source data."""
 
     @property
@@ -138,7 +142,7 @@ class Algorithm(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Citation:
+    def citation(self) -> meta_ctitation.Citation:
         """Information identifying the algorithm and version or date."""
 
     @property
@@ -152,12 +156,12 @@ class ProcessParameter(ABC):
 
     @property
     @abstractmethod
-    def name(self) -> MemberName:
+    def name(self) -> meta_naming.MemberName:
         """Name/type of parameter."""
 
     @property
     @abstractmethod
-    def direction(self) -> ParameterDirection:
+    def direction(self) -> meta_service.ParameterDirection:
         """
         Indication the parameter is an input to the process, an output,
         or both.
@@ -182,12 +186,12 @@ class ProcessParameter(ABC):
 
     @property
     @abstractmethod
-    def value_type(self) -> Optional[RecordType]:
+    def value_type(self) -> Optional[meta_naming.RecordType]:
         """Data type of the value"""
 
     @property
     @abstractmethod
-    def value(self) -> Optional[Record]:
+    def value(self) -> Optional[meta_naming.Record]:
         """Constant value."""
 
     @property
@@ -204,14 +208,15 @@ class Processing(ABC):
 
     @property
     @abstractmethod
-    def identifier(self) -> Identifier:
+    def identifier(self) -> meta_ctitation.Identifier:
         """
         Information to identify the processing package that produced the data.
         """
 
     @property
     @abstractmethod
-    def software_reference(self) -> Optional[Sequence[Citation]]:
+    def software_reference(self) -> \
+            Optional[Sequence[meta_ctitation.Citation]]:
         """Reference to document describing processing software."""
 
     @property
@@ -221,7 +226,7 @@ class Processing(ABC):
 
     @property
     @abstractmethod
-    def documentation(self) -> Optional[Sequence[Citation]]:
+    def documentation(self) -> Optional[Sequence[meta_ctitation.Citation]]:
         """Reference to documentation describing the processing."""
 
     @property
@@ -233,12 +238,12 @@ class Processing(ABC):
 
     @property
     @abstractmethod
-    def other_property(self) -> Optional[Record]:
+    def other_property(self) -> Optional[meta_naming.Record]:
         """Instance of other property type not included in `Sensor`."""
 
     @property
     @abstractmethod
-    def other_property_type(self) -> Optional[RecordType]:
+    def other_property_type(self) -> Optional[meta_naming.RecordType]:
         """Type of other property description."""
 
     @property
@@ -299,7 +304,7 @@ class ProcessStep(ABC):
 
     @property
     @abstractmethod
-    def processor(self) -> Optional[Sequence[Responsibility]]:
+    def processor(self) -> Optional[Sequence[meta_ctitation.Responsibility]]:
         """
         Identification of, and means of communication with, person(s) and
         organisation(s) associated with the process step.
@@ -307,12 +312,12 @@ class ProcessStep(ABC):
 
     @property
     @abstractmethod
-    def reference(self) -> Optional[Sequence[Citation]]:
+    def reference(self) -> Optional[Sequence[meta_ctitation.Citation]]:
         """Process step documentation."""
 
     @property
     @abstractmethod
-    def scope(self) -> Optional[Scope]:
+    def scope(self) -> Optional[meta_maintenance.Scope]:
         """Type of resource and/or extent to which the process step applies."""
 
     @property
@@ -361,7 +366,7 @@ class Lineage(ABC):
 
     @property
     @abstractmethod
-    def scope(self) -> Optional[Scope]:
+    def scope(self) -> Optional[meta_maintenance.Scope]:
         """
         Type of resource and/or extent to which the lineage information
         applies.
@@ -369,7 +374,8 @@ class Lineage(ABC):
 
     @property
     @abstractmethod
-    def additional_documentation(self) -> Optional[Sequence[Citation]]:
+    def additional_documentation(self) -> \
+            Optional[Sequence[meta_ctitation.Citation]]:
         """
         Resource.
 

--- a/geoapi/src/main/python/opengis/metadata/maintenance.py
+++ b/geoapi/src/main/python/opengis/metadata/maintenance.py
@@ -21,8 +21,7 @@ This module contains geographic metadata structures regarding data maintenance
 derived from the ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence, Set
@@ -30,8 +29,12 @@ from datetime import timedelta
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import Date, Responsibility
-from opengis.metadata.extent import Extent
+import opengis.metadata.citation as meta_citations
+import opengis.metadata.extent as meta_extent
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class MaintenanceFrequencyCode(Enum):
@@ -262,7 +265,7 @@ class Scope(ABC):
 
     @property
     @abstractmethod
-    def extent(self) -> Optional[Sequence[Extent]]:
+    def extent(self) -> Optional[Sequence[meta_extent.Extent]]:
         """
         Information about the horizontal, vertical, and temporal extent of
         the specified resource.
@@ -294,7 +297,7 @@ class MaintenanceInformation(ABC):
 
     @property
     @abstractmethod
-    def maintenance_date(self) -> Optional[Sequence[Date]]:
+    def maintenance_date(self) -> Optional[Sequence[meta_citations.Date]]:
         """Date information associated with maintenance of resource."""
 
     @property
@@ -322,7 +325,7 @@ class MaintenanceInformation(ABC):
 
     @property
     @abstractmethod
-    def contact(self) -> Optional[Sequence[Responsibility]]:
+    def contact(self) -> Optional[Sequence[meta_citations.Responsibility]]:
         """
         Identification of, and means of communicating with, person(s) and
         organisation(s) with responsibility for maintaining the metadata.

--- a/geoapi/src/main/python/opengis/metadata/naming.py
+++ b/geoapi/src/main/python/opengis/metadata/naming.py
@@ -21,12 +21,15 @@ This module contains geographic metadata structures regarding naming derived
 from the ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Any
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class NameSpace(ABC):

--- a/geoapi/src/main/python/opengis/metadata/quality.py
+++ b/geoapi/src/main/python/opengis/metadata/quality.py
@@ -23,8 +23,8 @@ ISO 19115-1:2014 international standard and data quality structures derived
 from the ISO 19157:2013, including addendum A1 (2018) international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
+
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -32,17 +32,18 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import Citation, Identifier
-from opengis.metadata.content import RangeDimension
-from opengis.metadata.distribution import DataFile, Format
-from opengis.metadata.identification import BrowseGraphic
-from opengis.metadata.maintenance import Scope
-from opengis.metadata.naming import Record, RecordType, TypeName
-from opengis.metadata.representation import (
-    SpatialRepresentation,
-    SpatialRepresentationTypeCode,
-)
-from opengis.util.measure import UnitOfMeasure
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.content as meta_content
+import opengis.metadata.distribution as meta_distribution
+import opengis.metadata.identification as meta_identification
+import opengis.metadata.maintenance as meta_maintenance
+import opengis.metadata.naming as meta_naming
+import opengis.metadata.representation as meta_representation
+import opengis.util.measure as util_measure
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class EvaluationMethodTypeCode(Enum):
@@ -110,7 +111,7 @@ class StandaloneQualityReportInformation(ABC):
 
     @property
     @abstractmethod
-    def report_reference(self) -> Citation:
+    def report_reference(self) -> meta_citation.Citation:
         """Reference to the associated standalone quality report."""
 
     @property
@@ -124,7 +125,7 @@ class Result(ABC):
 
     @property
     @abstractmethod
-    def result_scope(self) -> Scope:
+    def result_scope(self) -> meta_maintenance.Scope:
         """Scope of the result."""
 
     @property
@@ -148,12 +149,12 @@ class EvaluationMethod(ABC):
 
     @property
     @abstractmethod
-    def evaluation_procedure(self) -> Citation:
+    def evaluation_procedure(self) -> meta_citation.Citation:
         """Reference to the procedure information."""
 
     @property
     @abstractmethod
-    def reference_doc(self) -> Sequence[Citation]:
+    def reference_doc(self) -> Sequence[meta_citation.Citation]:
         """
         Information on documents which are referenced in developing and
         applying a data quality evaluation method.
@@ -172,7 +173,7 @@ class MeasureReference(ABC):
 
     @property
     @abstractmethod
-    def measure_identification(self) -> Identifier:
+    def measure_identification(self) -> meta_citation.Identifier:
         """
         Identifier of the measure, value uniquely identifying the measure
         within a namespace.
@@ -232,7 +233,7 @@ class DataQuality(ABC):
 
     @property
     @abstractmethod
-    def scope(self) -> Scope:
+    def scope(self) -> meta_maintenance.Scope:
         """The specific data to which the data quality information applies."""
 
     @property
@@ -259,7 +260,7 @@ class Description(ABC):
 
     @property
     @abstractmethod
-    def extended_description(self) -> BrowseGraphic:
+    def extended_description(self) -> meta_identification.BrowseGraphic:
         """Illustration."""
 
 
@@ -268,7 +269,7 @@ class SourceReference(ABC):
 
     @property
     @abstractmethod
-    def citation(self) -> Citation:
+    def citation(self) -> meta_citation.Citation:
         """References to the source."""
 
 
@@ -292,7 +293,7 @@ class BasicMeasure(ABC):
 
     @property
     @abstractmethod
-    def value_type(self) -> TypeName:
+    def value_type(self) -> meta_naming.TypeName:
         """
         Value type for the result of the basic measure (shall be one of the
         data types defined in ISO/TS 19103:2005).
@@ -319,12 +320,12 @@ class Parameter(ABC):
 
     @property
     @abstractmethod
-    def value_type(self) -> TypeName:
+    def value_type(self) -> meta_naming.TypeName:
         """
         Value type of the data quality parameter (shall be one of the data
         types defined in ISO/TS 19103:2005).
         """
-    
+
     @property
     @abstractmethod
     def value_structure(self) -> Optional[ValueStructure]:
@@ -336,7 +337,7 @@ class Measure(ABC):
 
     @property
     @abstractmethod
-    def measure_identifier(self) -> Identifier:
+    def measure_identifier(self) -> meta_citation.Identifier:
         """Value uniquely identifying the measure within a namespace."""
 
     @property
@@ -354,7 +355,7 @@ class Measure(ABC):
 
     @property
     @abstractmethod
-    def element_name(self) -> TypeName:
+    def element_name(self) -> meta_naming.TypeName:
         """Name of the data quality element for which quality is reported."""
 
     @property
@@ -374,7 +375,7 @@ class Measure(ABC):
 
     @property
     @abstractmethod
-    def value_type(self) -> TypeName:
+    def value_type(self) -> meta_naming.TypeName:
         """
         Value type for reporting a data quality result (shall be one of the
         data types defined in ISO/19103:2005).
@@ -618,7 +619,7 @@ class ConformanceResult(Result):
 
     @property
     @abstractmethod
-    def specification(self) -> Citation:
+    def specification(self) -> meta_citation.Citation:
         """
         Citation of data product specification or user requirement against
         which data is being evaluated.
@@ -646,12 +647,14 @@ class CoverageResult(Result):
 
     @property
     @abstractmethod
-    def spatial_representation_type(self) -> SpatialRepresentationTypeCode:
+    def spatial_representation_type(self) -> \
+            meta_representation.SpatialRepresentationTypeCode:
         """Method used to spatially represent the coverage result."""
 
     @property
     @abstractmethod
-    def result_spatial_representation(self) -> SpatialRepresentation:
+    def result_spatial_representation(self) -> \
+            meta_representation.SpatialRepresentation:
         """
         Gives a numerical representation of the data quality measurements
         making up the coverage result.
@@ -659,7 +662,8 @@ class CoverageResult(Result):
 
     @property
     @abstractmethod
-    def result_content(self) -> Optional[Sequence[RangeDimension]]:
+    def result_content(self) -> \
+            Optional[Sequence[meta_content.RangeDimension]]:
         """
         Describes the content of the result coverage, when the quality
         coverage is included in the described resource, i.e. the semantic
@@ -671,7 +675,7 @@ class CoverageResult(Result):
 
     @property
     @abstractmethod
-    def result_format(self) -> Optional[Format]:
+    def result_format(self) -> Optional[meta_distribution.Format]:
         """
         Provides information about the data format of the result coverage data.
 
@@ -682,7 +686,7 @@ class CoverageResult(Result):
     # Below property not defined in ISO 19157:2023
     @property
     @abstractmethod
-    def result_file(self) -> Optional[DataFile]:
+    def result_file(self) -> Optional[meta_distribution.DataFile]:
         """
         Provides information about the data file containing the result
         coverage data.
@@ -700,7 +704,7 @@ class QuantitativeResult(Result):
 
     @property
     @abstractmethod
-    def value(self) -> Sequence[Record]:
+    def value(self) -> Sequence[meta_naming.Record]:
         """
         Quantitative value or values, content determined by the evaluation
         procedure used, accordingly with the value type and valueStructure
@@ -709,12 +713,12 @@ class QuantitativeResult(Result):
 
     @property
     @abstractmethod
-    def value_unit(self) -> UnitOfMeasure:
+    def value_unit(self) -> util_measure.UnitOfMeasure:
         """Value unit for reporting a data quality result."""
 
     @property
     @abstractmethod
-    def value_record_type(self) -> RecordType:
+    def value_record_type(self) -> meta_naming.RecordType:
         """
         Value type for reporting a data quality result, depends of the
         implementation.

--- a/geoapi/src/main/python/opengis/metadata/representation.py
+++ b/geoapi/src/main/python/opengis/metadata/representation.py
@@ -22,20 +22,23 @@ derived from the ISO 19115-1:2014 and ISO 19115-2:2019 international
 standards.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
 from typing import Optional
 
-from opengis.geometry.primitive import DirectPosition, Point
-from opengis.metadata.citation import Citation
-from opengis.metadata.maintenance import Scope
-from opengis.metadata.naming import Record
-from opengis.metadata.quality import DataQuality, Element
-from opengis.referencing.crs import ReferenceSystem
+import opengis.geometry.primitive as primitive
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.maintenance as meta_maintenance
+import opengis.metadata.naming as meta_naming
+import opengis.metadata.quality as meta_quality
+import opengis.referencing.crs as crs
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class CellGeometryCode(Enum):
@@ -273,7 +276,7 @@ class GeolocationInformation(ABC):
 
     @property
     @abstractmethod
-    def quality_info(self) -> Optional[Sequence[DataQuality]]:
+    def quality_info(self) -> Optional[Sequence[meta_quality.DataQuality]]:
         """
         Provides an overall assessment of quality of geolocation information.
         """
@@ -284,7 +287,7 @@ class GCP(ABC):
 
     @property
     @abstractmethod
-    def geographic_coordinates(self) -> DirectPosition:
+    def geographic_coordinates(self) -> primitive.DirectPosition:
         """
         Geographic or map position of the control point, in either two
         or three dimensions.
@@ -292,7 +295,7 @@ class GCP(ABC):
 
     @property
     @abstractmethod
-    def accuracy_report(self) -> Optional[Sequence[Element]]:
+    def accuracy_report(self) -> Optional[Sequence[meta_quality.Element]]:
         """Accuracy of a ground control point."""
 
 
@@ -311,7 +314,7 @@ class GCPCollection(GeolocationInformation):
 
     @property
     @abstractmethod
-    def coordinate_reference_system(self) -> ReferenceSystem:
+    def coordinate_reference_system(self) -> crs.ReferenceSystem:
         """Coordinate system in which the ground control points are defined."""
 
     @property
@@ -350,7 +353,7 @@ class SpatialRepresentation(ABC):
 
     @property
     @abstractmethod
-    def scope(self) -> Optional[Scope]:
+    def scope(self) -> Optional[meta_maintenance.Scope]:
         """Level and extent of the spatial representation."""
 
 
@@ -428,7 +431,7 @@ class Georectified(GridSpatialRepresentation):
 
     @property
     @abstractmethod
-    def corner_points(self) -> Optional[Sequence[Point]]:
+    def corner_points(self) -> Optional[Sequence[primitive.Point]]:
         """
         Earth location in the coordinate system defined by the Spatial
         Reference System and the grid coordinate of the cells at opposite ends
@@ -443,7 +446,7 @@ class Georectified(GridSpatialRepresentation):
 
     @property
     @abstractmethod
-    def centre_point(self) -> Optional[Point]:
+    def centre_point(self) -> Optional[primitive.Point]:
         """
         Earth location in the coordinate system defined by the Spatial
         Reference System and the grid coordinate of the cell halfway between
@@ -510,12 +513,12 @@ class Georeferenceable(GridSpatialRepresentation):
 
     @property
     @abstractmethod
-    def georeferenced_parameters(self) -> Record:
+    def georeferenced_parameters(self) -> meta_naming.Record:
         """Terms which support grid data georeferencing."""
 
     @property
     @abstractmethod
-    def parameter_citation(self) -> Optional[Sequence[Citation]]:
+    def parameter_citation(self) -> Optional[Sequence[meta_citation.Citation]]:
         """Reference providing description of the parameters."""
 
     @property

--- a/geoapi/src/main/python/opengis/metadata/service.py
+++ b/geoapi/src/main/python/opengis/metadata/service.py
@@ -21,18 +21,21 @@ This module contains geographic metadata structures regarding data services
 derived from the ISO 19115-1:2014 international standard.
 """
 
-__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import Citation, OnlineResource
-from opengis.metadata.distribution import StandardOrderProcess
-from opengis.metadata.identification import DataIdentification, Identification
-from opengis.metadata.naming import GenericName, MemberName, ScopedName
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.distribution as meta_distribution
+import opengis.metadata.identification as meta_identification
+import opengis.metadata.naming as meta_naming
+
+
+__author__ = "OGC Topic 11 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class CouplingType(Enum):
@@ -139,7 +142,7 @@ class CoupledResource(ABC):
 
     @property
     @abstractmethod
-    def scoped_name(self) -> Optional[ScopedName]:
+    def scoped_name(self) -> Optional[meta_naming.ScopedName]:
         """
         Scoped identifier of the resource in the context of the given service
         instance.
@@ -156,7 +159,7 @@ class CoupledResource(ABC):
 
     @property
     @abstractmethod
-    def resource_reference(self) -> Optional[Sequence[Citation]]:
+    def resource_reference(self) -> Optional[Sequence[meta_citation.Citation]]:
         """
         Reference to the dataset on which the service operates.
 
@@ -166,7 +169,8 @@ class CoupledResource(ABC):
 
     @property
     @abstractmethod
-    def resource(self) -> Optional[Sequence[DataIdentification]]:
+    def resource(self) -> \
+            Optional[Sequence[meta_identification.DataIdentification]]:
         """
         The tightly coupled resource.
 
@@ -186,7 +190,7 @@ class CoupledResource(ABC):
         """
 
 
-class ServiceIdentification(Identification):
+class ServiceIdentification(meta_identification.Identification):
     """
     Identification of capabilities which a service provider makes available to
     a service user through a set of interfaces that define a behaviour.
@@ -196,7 +200,7 @@ class ServiceIdentification(Identification):
 
     @property
     @abstractmethod
-    def service_type(self) -> GenericName:
+    def service_type(self) -> meta_naming.GenericName:
         """
         A service type name, e.g., 'discovery', 'view', 'download',
         'transformation', or 'invoke'.
@@ -215,7 +219,8 @@ class ServiceIdentification(Identification):
 
     @property
     @abstractmethod
-    def access_properties(self) -> Optional[StandardOrderProcess]:
+    def access_properties(self) -> \
+            Optional[meta_distribution.StandardOrderProcess]:
         """
         Information about the availability of the service, including 'fees',
         'planned', 'available date and time', 'ordering instructions',
@@ -242,19 +247,19 @@ class ServiceIdentification(Identification):
 
     @property
     @abstractmethod
-    def operated_dataset(self) -> Optional[Sequence[Citation]]:
+    def operated_dataset(self) -> Optional[Sequence[meta_citation.Citation]]:
         """
         Provides a reference to the dataset on which the service operates.
         """
 
     @property
     @abstractmethod
-    def profile(self) -> Optional[Sequence[Citation]]:
+    def profile(self) -> Optional[Sequence[meta_citation.Citation]]:
         """Profile to which the service adheres."""
 
     @property
     @abstractmethod
-    def service_standard(self) -> Optional[Sequence[Citation]]:
+    def service_standard(self) -> Optional[Sequence[meta_citation.Citation]]:
         """Standard to which the service adheres."""
 
     @property
@@ -266,7 +271,8 @@ class ServiceIdentification(Identification):
 
     @property
     @abstractmethod
-    def operates_on(self) -> Optional[Sequence[DataIdentification]]:
+    def operates_on(self) -> \
+            Optional[Sequence[meta_identification.DataIdentification]]:
         """
         Provides information about the resources on which the service operates.
 
@@ -285,7 +291,7 @@ class Parameter(ABC):
 
     @property
     @abstractmethod
-    def name(self) -> MemberName:
+    def name(self) -> meta_naming.MemberName:
         """The name, as used by the service, for this parameter."""
 
     @property
@@ -350,7 +356,7 @@ class OperationMetadata(ABC):
 
     @property
     @abstractmethod
-    def connect_point(self) -> Sequence[OnlineResource]:
+    def connect_point(self) -> Sequence[meta_citation.OnlineResource]:
         """Handle for accessing the service interface."""
 
     @property

--- a/geoapi/src/main/python/opengis/referencing/common.py
+++ b/geoapi/src/main/python/opengis/referencing/common.py
@@ -21,17 +21,19 @@ This module contains geographic metadata structures derived from the
 Common Classes package in the ISO 19111:2019 international standard.
 """
 
-__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
-    "David Meaux (Geomatys)"
-
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Optional
 
-from opengis.metadata.citation import Identifier
-from opengis.metadata.extent import Extent
-from opengis.metadata.naming import GenericName
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.extent as meta_extent
+import opengis.metadata.naming as naming
+
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "David Meaux (Geomatys)"
 
 
 class ObjectDomain(ABC):
@@ -47,7 +49,7 @@ class ObjectDomain(ABC):
 
     @property
     @abstractmethod
-    def domain_of_validity(self) -> Extent:
+    def domain_of_validity(self) -> meta_extent.Extent:
         """The spatial and temporal extent in which this object is valid."""
 
 
@@ -56,12 +58,12 @@ class IdentifiedObject(ABC):
 
     @property
     @abstractmethod
-    def name(self) -> Identifier:
+    def name(self) -> meta_citation.Identifier:
         """The primary name by which this object is identified."""
 
     @property
     @abstractmethod
-    def identifier(self) -> Optional[Sequence[Identifier]]:
+    def identifier(self) -> Optional[Sequence[meta_citation.Identifier]]:
         """
         An identifier which references elsewhere the object's defining
         information; alternatively an identifier by which this object can be
@@ -70,7 +72,7 @@ class IdentifiedObject(ABC):
 
     @property
     @abstractmethod
-    def alias(self) -> Optional[Sequence[GenericName]]:
+    def alias(self) -> Optional[Sequence[naming.GenericName]]:
         """An alternative name by which this object is identified."""
 
     @property

--- a/geoapi/src/main/python/opengis/referencing/coordinate.py
+++ b/geoapi/src/main/python/opengis/referencing/coordinate.py
@@ -21,16 +21,19 @@ This module contains geographic metadata structures derived from the
 Coordinates package in the ISO 19111:2019 international standard.
 """
 
-__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
-    "David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Optional
 
-from opengis.geometry.primitive import DirectPosition
-from opengis.referencing.crs import CoordinateReferenceSystem
-from opengis.util.measure import Measure
+import opengis.geometry.primitive as primitive
+import opengis.referencing.crs as crs
+import opengis.util.measure as measure
+
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "David Meaux (Geomatys)"
 
 
 class DataEpoch(ABC):
@@ -40,7 +43,7 @@ class DataEpoch(ABC):
 
     @property
     @abstractmethod
-    def coordinate_epoch(self) -> Measure:
+    def coordinate_epoch(self) -> measure.Measure:
         """
         The date at which coordinates are referenced to a dynamic coordinate
         reference system, expressed as a decimal year in the Gregorian
@@ -60,7 +63,7 @@ class CoordinateSet(ABC):
 
     @property
     @abstractmethod
-    def coordinate_tuple(self) -> Sequence[DirectPosition]:
+    def coordinate_tuple(self) -> Sequence[primitive.DirectPosition]:
         """Position described by a coordinate tuple."""
 
 
@@ -71,7 +74,7 @@ class CoordinateMetadata(ABC):
 
     @property
     @abstractmethod
-    def coordinate_referencea_system(self) -> CoordinateReferenceSystem:
+    def coordinate_referencea_system(self) -> crs.CoordinateReferenceSystem:
         """
         Identifier of the coordinate reference system to which a coordinate
         set is referenced.

--- a/geoapi/src/main/python/opengis/referencing/crs.py
+++ b/geoapi/src/main/python/opengis/referencing/crs.py
@@ -22,32 +22,23 @@ referencing systems derived from the ISO 19111 international standard and
 ISO 19115-1:2014, including adendums A1(2018) and A2(2020).
 """
 
-__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Sequence
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.citation import Identifier
-from opengis.referencing.common import IdentifiedObject
-from opengis.referencing.coordinate import DataEpoch
-from opengis.referencing.cs import (
-    CartesianCS,
-    CoordinateSystem,
-    EllipsoidalCS,
-    TimeCS,
-    VerticalCS,
-)
-from opengis.referencing.datum import (
-    Datum,
-    EngineeringDatum,
-    GeodeticDatum,
-    TemporalDatum,
-    VerticalDatum,
-)
-from opengis.referencing.operation import Conversion
+import opengis.metadata.citation as citation
+import opengis.referencing.common as ref_common
+import opengis.referencing.coordinate as ref_coordinate
+import opengis.referencing.cs as cs
+import opengis.referencing.datum as ref_datum
+import opengis.referencing.operation as ref_operation
+
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class ReferenceSystemTypeCode(Enum):
@@ -328,7 +319,7 @@ class ReferenceSystemTypeCode(Enum):
     """
 
 
-class ReferenceSystem(IdentifiedObject):
+class ReferenceSystem(ref_common.IdentifiedObject):
     """
     Description of a spatial and temporal reference system used by a dataset.
 
@@ -338,7 +329,7 @@ class ReferenceSystem(IdentifiedObject):
     """
     @property
     @abstractmethod
-    def reference_system_identifier(self) -> Optional[Identifier]:
+    def reference_system_identifier(self) -> Optional[citation.Identifier]:
         """
         Identifier and codespace for reference system.
 
@@ -367,7 +358,7 @@ class ReferenceSystem(IdentifiedObject):
 
     @property
     @abstractmethod
-    def coordinate_epoch(self) -> Optional[DataEpoch]:
+    def coordinate_epoch(self) -> Optional[ref_coordinate.DataEpoch]:
         """
         The epoch from which coordinates in a dynamic coordinate reference
         system are referenced.
@@ -403,7 +394,7 @@ class SingleCRS(CoordinateReferenceSystem):
 
     @property
     @abstractmethod
-    def coordinate_system(self) -> CoordinateSystem:
+    def coordinate_system(self) -> cs.CoordinateSystem:
         """
         Returns the coordinate system.
 
@@ -413,7 +404,7 @@ class SingleCRS(CoordinateReferenceSystem):
 
     @property
     @abstractmethod
-    def datum(self) -> Datum:
+    def datum(self) -> ref_datum.Datum:
         """
         Returns the datum.
 
@@ -446,7 +437,7 @@ class VerticalCRS(SingleCRS):
 
     @property
     @abstractmethod
-    def coordinate_system(self) -> VerticalCS:
+    def coordinate_system(self) -> cs.VerticalCS:
         """
         Returns the coordinate system, which must be vertical.
 
@@ -456,7 +447,7 @@ class VerticalCRS(SingleCRS):
 
     @property
     @abstractmethod
-    def datum(self) -> VerticalDatum:
+    def datum(self) -> ref_datum.VerticalDatum:
         """
         Returns the datum, which must be vertical.
 
@@ -472,7 +463,7 @@ class TemporalCRS(SingleCRS):
 
     @property
     @abstractmethod
-    def coordinate_system(self) -> TimeCS:
+    def coordinate_system(self) -> cs.TimeCS:
         """
         Returns the coordinate system, which must be temporal.
 
@@ -482,7 +473,7 @@ class TemporalCRS(SingleCRS):
 
     @property
     @abstractmethod
-    def datum(self) -> TemporalDatum:
+    def datum(self) -> ref_datum.TemporalDatum:
         """
         Returns the datum, which must be temporal.
 
@@ -498,7 +489,7 @@ class EngineeringCRS(SingleCRS):
 
     @property
     @abstractmethod
-    def datum(self) -> EngineeringDatum:
+    def datum(self) -> ref_datum.EngineeringDatum:
         """
         Returns the datum, which must be an engineering one.
 
@@ -525,7 +516,7 @@ class DerivedCRS(SingleCRS):
 
     @property
     @abstractmethod
-    def conversion_from_base(self) -> Conversion:
+    def conversion_from_base(self) -> ref_operation.Conversion:
         """
         Returns the conversion from the base CRS to this CRS.
 
@@ -541,7 +532,7 @@ class GeodeticCRS(SingleCRS):
 
     @property
     @abstractmethod
-    def datum(self) -> GeodeticDatum:
+    def datum(self) -> ref_datum.GeodeticDatum:
         """
         Returns the datum, which must be geodetic.
 
@@ -559,7 +550,7 @@ class GeographicCRS(GeodeticCRS):
 
     @property
     @abstractmethod
-    def coordinate_system(self) -> EllipsoidalCS:
+    def coordinate_system(self) -> cs.EllipsoidalCS:
         """
         Returns the coordinate system, which must be ellipsoidal.
 
@@ -576,7 +567,7 @@ class ProjectedCRS(DerivedCRS):
 
     @property
     @abstractmethod
-    def conversion_from_base(self) -> Conversion:
+    def conversion_from_base(self) -> ref_operation.Conversion:
         """
         Returns the map projection from the base CRS to this CRS.
 
@@ -596,7 +587,7 @@ class ProjectedCRS(DerivedCRS):
 
     @property
     @abstractmethod
-    def coordinate_system(self) -> CartesianCS:
+    def coordinate_system(self) -> cs.CartesianCS:
         """
         Returns the coordinate system, which must be cartesian.
 
@@ -606,7 +597,7 @@ class ProjectedCRS(DerivedCRS):
 
     @property
     @abstractmethod
-    def datum(self) -> GeodeticDatum:
+    def datum(self) -> ref_datum.GeodeticDatum:
         """
         Returns the datum.
 

--- a/geoapi/src/main/python/opengis/referencing/cs.py
+++ b/geoapi/src/main/python/opengis/referencing/cs.py
@@ -21,13 +21,16 @@ This module contains geographic metadata structures regarding coordinate
 systems derived from the ISO 19111 international standard.
 """
 
-__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import abstractmethod
 from enum import Enum
 
-from opengis.referencing.common import IdentifiedObject
+import opengis.referencing.common as ref_common
+
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class AxisDirection(Enum):
@@ -213,7 +216,7 @@ class RangeMeaning(Enum):
     """
 
 
-class CoordinateSystemAxis(IdentifiedObject):
+class CoordinateSystemAxis(ref_common.IdentifiedObject):
     """
     Definition of a coordinate system axis.
     """
@@ -294,7 +297,7 @@ class CoordinateSystemAxis(IdentifiedObject):
         """
 
 
-class CoordinateSystem(IdentifiedObject):
+class CoordinateSystem(ref_common.IdentifiedObject):
     """
     The set of coordinate system axes that spans a given coordinate space.
     A coordinate system (CS) is derived from a set of (mathematical) rules for

--- a/geoapi/src/main/python/opengis/referencing/datum.py
+++ b/geoapi/src/main/python/opengis/referencing/datum.py
@@ -21,17 +21,20 @@ This module contains geographic metadata structures regarding datums derived
 from the ISO 19111 international standard.
 """
 
-__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import abstractmethod
 from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from opengis.metadata.extent import Extent
-from opengis.referencing.common import IdentifiedObject
-from opengis.util.measure import UomAngle, UomLength
+import opengis.metadata.extent as meta_extent
+import opengis.referencing.common as ref_common
+import opengis.util.measure as measure
+
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class RealizationMethod(Enum):
@@ -55,7 +58,7 @@ class RealizationMethod(Enum):
     """The realization is through a tidal model or by tidal predictions."""
 
 
-class Datum(IdentifiedObject):
+class Datum(ref_common.IdentifiedObject):
     """
     Specifies the relationship of a coordinate system to the earth, thus
     creating a coordinate reference system.
@@ -71,7 +74,7 @@ class Datum(IdentifiedObject):
 
     @property
     @abstractmethod
-    def domain_of_validity(self) -> Extent:
+    def domain_of_validity(self) -> meta_extent.Extent:
         """
         Information about spatial, vertical, and temporal extent. This
         interface has four optional attributes (geographic elements, temporal
@@ -138,7 +141,7 @@ class VerticalDatum(Datum):
         """
 
 
-class Ellipsoid(IdentifiedObject):
+class Ellipsoid(ref_common.IdentifiedObject):
     """
     Geometric figure that can be used to describe the approximate shape of the
     Earth.
@@ -146,7 +149,7 @@ class Ellipsoid(IdentifiedObject):
 
     @property
     @abstractmethod
-    def axis_unit(self) -> UomLength:
+    def axis_unit(self) -> measure.UomLength:
         """
         Linear unit of the semi-major and semi-minor axis values.
         """
@@ -195,7 +198,7 @@ class Ellipsoid(IdentifiedObject):
         """
 
 
-class PrimeMeridian(IdentifiedObject):
+class PrimeMeridian(ref_common.IdentifiedObject):
     """
     A prime meridian defines the origin from which longitude values are
     determined.
@@ -211,7 +214,7 @@ class PrimeMeridian(IdentifiedObject):
 
     @property
     @abstractmethod
-    def angular_unit(self) -> UomAngle:
+    def angular_unit(self) -> measure.UomAngle:
         """
         Returns the angular unit of the Greenwich longitude.
         """

--- a/geoapi/src/main/python/opengis/referencing/operation.py
+++ b/geoapi/src/main/python/opengis/referencing/operation.py
@@ -21,8 +21,7 @@ This module contains geographic metadata structures regarding referencing
 system operations derived from the ISO 19111 international standard.
 """
 
-__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
-    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -30,15 +29,19 @@ from typing import Any, Optional
 
 import numpy as np
 
-from opengis.geometry.primitive import DirectPosition
-from opengis.metadata.citation import Citation
-from opengis.metadata.extent import Extent
-from opengis.metadata.quality import PositionalAccuracy
-from opengis.referencing.common import IdentifiedObject
-from opengis.referencing.crs import CoordinateReferenceSystem
+import opengis.geometry.primitive as primitive
+import opengis.metadata.citation as meta_citation
+import opengis.metadata.extent as meta_extent
+import opengis.metadata.quality as quality
+import opengis.referencing.common as ref_common
+import opengis.referencing.crs as crs
 
 # TODO :
 # from opengis.parameter import ParameterValueGroup, ParameterDescriptorGroup
+
+
+__author__ = "OGC Topic 2 (for abstract model and documentation), " +\
+    "Martin Desruisseaux (Geomatys), David Meaux (Geomatys)"
 
 
 class MathTransform(ABC):
@@ -85,17 +88,17 @@ class MathTransform(ABC):
         """
 
     @abstractmethod
-    def transform(self, pt_src: DirectPosition,
-                  pt_dst: Optional[DirectPosition]) ->\
-            DirectPosition | np.ndarray:
+    def transform(self, pt_src: primitive.DirectPosition,
+                  pt_dst: Optional[primitive.DirectPosition]) ->\
+            primitive.DirectPosition | np.ndarray:
         """
         Transforms the specified pt_src and stores the result in pt_dst.
 
         Arguments:
             pt_src (DirectPosition): the specified coordinate point to
                 be transformed.
-            pt_dst (Optional[DirectPosition]): the specified coordinate point that
-                stores the result of transforming ptSrc, or null.
+            pt_dst (Optional[DirectPosition]): the specified coordinate point
+                that stores the result of transforming ptSrc, or null.
         Returns:
             The coordinate point or an array of coordinate points
                 after transforming pt_src and storing the result in pt_dst,
@@ -110,7 +113,7 @@ class MathTransform(ABC):
         dst_pts: np.ndarray,
         dst_off: int,
         num_pts: int,
-        ):
+    ):
         """
         Transforms a list of coordinate point ordinal values. This method is
         provided for efficiently transforming many points. The supplied array
@@ -134,7 +137,7 @@ class MathTransform(ABC):
         """
 
     @abstractmethod
-    def derivative(self, point: DirectPosition) -> np.ndarray:
+    def derivative(self, point: primitive.DirectPosition) -> np.ndarray:
         """
         Gets the derivative of this transform at a point (never null).
         The derivative is the matrix of the non-translating portion of
@@ -201,14 +204,14 @@ class Formula:
 
     @property
     @abstractmethod
-    def citation(self) -> Optional[Citation]:
+    def citation(self) -> Optional[meta_citation.Citation]:
         """
         Reference to a publication giving the formula(s) or procedure used by
         the coordinate operation method, or null if `None`.
         """
 
 
-class OperationMethod(IdentifiedObject):
+class OperationMethod(ref_common.IdentifiedObject):
     """
     Definition of an algorithm used to perform a coordinate operation.
     """
@@ -231,7 +234,7 @@ class OperationMethod(IdentifiedObject):
     #     """
 
 
-class CoordinateOperation(IdentifiedObject):
+class CoordinateOperation(ref_common.IdentifiedObject):
     """
     A mathematical operation on coordinates that transforms or converts
     coordinates to another coordinate reference system.
@@ -239,7 +242,7 @@ class CoordinateOperation(IdentifiedObject):
 
     @property
     @abstractmethod
-    def source_crs(self) -> Optional[CoordinateReferenceSystem]:
+    def source_crs(self) -> Optional[crs.CoordinateReferenceSystem]:
         """
         Returns the source CRS. The source CRS is mandatory for
         transformations only. Conversions may have a source CRS that is not
@@ -249,7 +252,7 @@ class CoordinateOperation(IdentifiedObject):
 
     @property
     @abstractmethod
-    def target_crs(self) -> Optional[CoordinateReferenceSystem]:
+    def target_crs(self) -> Optional[crs.CoordinateReferenceSystem]:
         """
         Returns the target CRS. The target CRS is mandatory for
         transformations only. Conversions may have a target CRS that is not
@@ -272,7 +275,7 @@ class CoordinateOperation(IdentifiedObject):
     @property
     @abstractmethod
     def coordinate_operation_accuracy(self) ->\
-            Sequence[Optional[PositionalAccuracy]]:
+            Sequence[Optional[quality.PositionalAccuracy]]:
         """
         Estimate(s) of the impact of this operation on point accuracy. Gives
         position error estimates for target coordinates of this coordinate
@@ -282,7 +285,7 @@ class CoordinateOperation(IdentifiedObject):
 
     @property
     @abstractmethod
-    def domain_of_validity(self) -> Optional[Extent]:
+    def domain_of_validity(self) -> Optional[meta_extent.Extent]:
         """
         Area or region or timeframe in which this coordinate operation is
         valid or `None` if not available.
@@ -358,14 +361,14 @@ class Transformation(SingleOperation):
 
     @property
     @abstractmethod
-    def source_crs(self) -> CoordinateReferenceSystem:
+    def source_crs(self) -> crs.CoordinateReferenceSystem:
         """
         Returns the source CRS (never null).
         """
 
     @property
     @abstractmethod
-    def target_crs(self) -> CoordinateReferenceSystem:
+    def target_crs(self) -> crs.CoordinateReferenceSystem:
         """
         Returns the target CRS (never null).
         """
@@ -387,7 +390,7 @@ class Conversion(SingleOperation):
 
     @property
     @abstractmethod
-    def source_crs(self) -> Optional[CoordinateReferenceSystem]:
+    def source_crs(self) -> Optional[crs.CoordinateReferenceSystem]:
         """
         Returns the source CRS. Conversions may have a source CRS that is not
         specified here, but through `DerivedCRS.getBaseCRS()` instead. `None`
@@ -396,7 +399,7 @@ class Conversion(SingleOperation):
 
     @property
     @abstractmethod
-    def target_crs(self) -> Optional[CoordinateReferenceSystem]:
+    def target_crs(self) -> Optional[crs.CoordinateReferenceSystem]:
         """
         Returns the target CRS. Conversions may have a target CRS that is not
         specified here, but through `DerivedCRS` instead. `None`

--- a/geoapi/src/main/python/opengis/util/measure.py
+++ b/geoapi/src/main/python/opengis/util/measure.py
@@ -22,14 +22,17 @@ specification for which no equivalence is already present in the Python
 standard library.
 """
 
-__author__ = "OGC Topic 20 (for abstract model and documentation), " +\
-    "David Meaux (Geomatys)"
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Optional
 
-from opengis.geometry.primitive import Vector
+import opengis.geometry.primitive as primitive
+
+
+__author__ = "OGC Topic 20 (for abstract model and documentation), " +\
+    "David Meaux (Geomatys)"
 
 
 class StandardUnits(Enum):
@@ -377,7 +380,7 @@ class DirectedMeasure(ABC):
 
     @property
     @abstractmethod
-    def value(self) -> Vector:
+    def value(self) -> primitive.Vector:
         """
         The magnitude and direction of the directed measure.
         """


### PR DESCRIPTION
FIX: Circular import errors

Fixed multiple circular import errors in Python using `from __future__ import annotations` with general module import to delay functions being imported at runtime.

Example:
```python
from __future__ import annotations

import opengis.geometry.primitive as primitive

class DirectedMeasure(ABC):
    """
    A DirectedMeasure is the result of ascertaining the value of
    a characteristic of some entity where direction is an essential aspect
    of the characteristic.
    """

    @property
    @abstractmethod
    def value(self) -> primitive.Vector:
        """
        The magnitude and direction of the directed measure.
        """
```