### PR TITLE
FIX: Python, make metadata.citation.Party.contact_info optional according to ISO 19115

### DIFF
--- a/geoapi/src/main/python/opengis/metadata/citation.py
+++ b/geoapi/src/main/python/opengis/metadata/citation.py
@@ -568,7 +568,7 @@ class Party(ABC):
 
     @property
     @abstractmethod
-    def contact_info(self) -> Sequence[Contact]:
+    def contact_info(self) -> Optional[Sequence[Contact]]:
         """Contact information for the party."""
 
     @property


### PR DESCRIPTION
FIX: Make `Party.contact_info`  (in Python `metadata.citation`) optional according to ISO 19115.