### PR TITLE
FIX: Python, make metadata.content.SampleDimension.range_element_description optional

### DIFF
--- a/geoapi/src/main/python/opengis/metadata/content.py
+++ b/geoapi/src/main/python/opengis/metadata/content.py
@@ -406,7 +406,9 @@ class SampleDimension(RangeDimension):
 
     @property
     @abstractmethod
-    def range_element_description(self) -> Sequence[RangeElementDescription]:
+    def range_element_description(self) -> Optional[
+            Sequence[RangeElementDescription]
+            ]:
         """
         Provides the description and values of the specific range elements of
         a sample dimension.


### PR DESCRIPTION
FIX: Python - Make metadata.content.SampleDimension.range_element_description optional in accordance with ISO 19115.